### PR TITLE
fix(loader): improve format detection and add fallback parsing

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/kvx/internal/cel"
 	"github.com/oakwood-commons/kvx/internal/formatter"
 	"github.com/oakwood-commons/kvx/internal/navigator"
@@ -109,9 +110,21 @@ func LoadRootBytes(data []byte) (interface{}, error) {
 	return loader.LoadRootBytes(data)
 }
 
+// LoadRootBytesWithLogger is like LoadRootBytes but accepts a logger for
+// recording fallback parse attempts.
+func LoadRootBytesWithLogger(data []byte, lgr logr.Logger) (interface{}, error) {
+	return loader.LoadRootBytesWithLogger(data, lgr)
+}
+
 // LoadFile reads a file and parses it into a single root node.
 func LoadFile(path string) (interface{}, error) {
 	return loader.LoadFile(path)
+}
+
+// LoadFileWithLogger is like LoadFile but accepts a logger for recording
+// fallback parse attempts and extension-based dispatch.
+func LoadFileWithLogger(path string, lgr logr.Logger) (interface{}, error) {
+	return loader.LoadFileWithLogger(path, lgr)
 }
 
 // LoadObject accepts an already parsed object and returns it directly.


### PR DESCRIPTION
- Tighten isLikelyTOML heuristic to require column-0 patterns and both section headers and key-value lines, preventing false positives on indented YAML content like `["legacy"]`
- Honor file extensions (.yaml, .yml, .json, .toml, .ndjson, .jsonl) before falling back to content-based heuristics
- Add fallback parsing: when the detected format fails, try remaining parsers in order and log each attempt via logr
- Add WithLogger variants to loader and core packages for structured logging of parse attempts
- Remove redundant isTOMLFile/parseTOML from cmd/root.go (consolidated into pkg/loader)

Fixes parsing of YAML files containing bracket notation in string values that were incorrectly detected as TOML section headers.

## Description

Brief description of the changes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue

Fixes #(issue number)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `golangci-lint run` and fixed any issues
- [ ] I have run `go test ./...` and all tests pass
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed

## Testing

Describe how you tested these changes.

## Screenshots (if applicable)

Add screenshots for UI changes.
