### PR TITLE
feat: add auto output format with smart table-to-list fallback

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -122,7 +122,7 @@ func captureOutput(t *testing.T, fn func()) string {
 
 func resetRootCmdState() {
 	interactive = false
-	output = "table"
+	output = "auto"
 	expression = ""
 	searchTerm = ""
 	debug = false

--- a/internal/formatter/list.go
+++ b/internal/formatter/list.go
@@ -80,9 +80,13 @@ func formatArrayAsList(arr []interface{}, opts ListOptions) string {
 				b.WriteString("\n")
 			}
 
-			// Indented properties
+			// Indented properties (only indent when there's a visible header)
+			indent := "  "
+			if headerStr == "" {
+				indent = ""
+			}
 			if m, ok := elem.(map[string]interface{}); ok {
-				b.WriteString(formatMapAsList(m, "  ", opts.NoColor))
+				b.WriteString(formatMapAsList(m, indent, opts.NoColor))
 			}
 		}
 	} else {

--- a/internal/formatter/list_test.go
+++ b/internal/formatter/list_test.go
@@ -148,6 +148,38 @@ func TestFormatAsListNoColor(t *testing.T) {
 	}
 }
 
+func TestFormatAsListArrayOfObjectsNoIndex(t *testing.T) {
+	arr := []interface{}{
+		map[string]interface{}{"name": "Alice", "age": 30},
+		map[string]interface{}{"name": "Bob", "age": 25},
+	}
+	// Default style "none" should produce no index headers
+	result := FormatAsList(arr, ListOptions{NoColor: true, ArrayStyle: "none"})
+
+	// Should NOT contain index markers
+	if strings.Contains(result, "[0]") {
+		t.Fatalf("expected no index markers with style 'none', got %q", result)
+	}
+	if strings.Contains(result, "[1]") {
+		t.Fatalf("expected no index markers with style 'none', got %q", result)
+	}
+
+	// Should still contain properties without indent
+	if !strings.Contains(result, "name: Alice") {
+		t.Fatalf("expected 'name: Alice' in output, got %q", result)
+	}
+	if !strings.Contains(result, "age: 25") {
+		t.Fatalf("expected 'age: 25' in output, got %q", result)
+	}
+
+	// Should NOT have leading spaces (no indent when no index)
+	for _, line := range strings.Split(strings.TrimSpace(result), "\n") {
+		if strings.HasPrefix(line, "  ") {
+			t.Fatalf("expected no leading indent with style 'none', got line %q", line)
+		}
+	}
+}
+
 func TestFormatAsListWithColor(t *testing.T) {
 	// Test with noColor=false to ensure color codes are present
 	m := map[string]interface{}{"key": "value"}


### PR DESCRIPTION
Add a new "auto" output format that intelligently chooses between table and list view based on terminal width and column readability. This prevents truncated, unreadable table output when there are too many columns for the available width.

Changes:
- Add IsColumnarReadable() function to detect when table columns would be shrunk below 8 characters (unreadable threshold)
- Add "auto" output format as the new default (-o auto)
- Auto mode renders as table when columns fit, falls back to list when they don't
- Change default --array-style from "index" to "none" for cleaner list output without [0], [1] headers
- Fix list view indentation to not add leading spaces when no index is displayed

Users can still force specific formats with -o table or -o list, and opt into index headers with --array-style index.