### PR TITLE
fix(loader): normalize carriage returns to newlines before parsing

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -89,6 +89,11 @@ func LoadData(input string) ([]interface{}, error) {
 // LoadDataWithLogger is like LoadData but accepts a logger for
 // recording fallback parse attempts.
 func LoadDataWithLogger(input string, lgr logr.Logger) ([]interface{}, error) {
+	// Normalize line endings: \r\n → \n, then standalone \r → \n
+	// This handles Windows line endings and carriage returns from
+	// progress indicators (e.g., CLI tools that overwrite lines).
+	input = strings.ReplaceAll(input, "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return nil, fmt.Errorf("empty input")
@@ -256,7 +261,11 @@ func LoadFileWithLogger(path string, lgr logr.Logger) (interface{}, error) {
 		return nil, err
 	}
 
-	input := string(data)
+	// Normalize line endings: \r\n → \n, then standalone \r → \n
+	// This handles Windows line endings and carriage returns from
+	// progress indicators (e.g., CLI tools that overwrite lines).
+	input := strings.ReplaceAll(string(data), "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
 
 	// Honor the file extension first.
 	ext := filepath.Ext(path)


### PR DESCRIPTION
CLI tools like scafctl use carriage returns (\r) for progress indicators, which can cause multiple JSON objects to appear on the same "line" when piped to kvx. This results in JSON parsing errors when valid JSON is followed by non-JSON content (e.g., emoji error messages) separated only by \r.

Normalize \r\n → \n and \r → \n before splitting lines, ensuring each JSON object is parsed independently regardless of the source's line ending conventions.