### PR TITLE
fix(formatter): calculate table width using display names and hints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1011,9 +1011,9 @@ func renderColumnarBorderedTable(node interface{}, noColor bool, widthHint int, 
 		return renderBorderedTable(node, noColor, 0, 0, termWidth, appName, path)
 	}
 
-	// Calculate natural content width (no caps, no truncation)
+	// Calculate natural content width accounting for hidden columns and display name overrides
 	showRowNum := tableOpts.ArrayStyle != "none"
-	naturalContentWidth := formatter.CalculateNaturalColumnarWidth(columns, rows, showRowNum, len(rows))
+	naturalContentWidth := formatter.CalculateNaturalColumnarWidthWithHints(columns, rows, showRowNum, len(rows), tableOpts.ColumnHints, tableOpts.HiddenColumns)
 
 	// Table width: use natural width if it fits, otherwise use terminal width
 	tableWidth := termWidth
@@ -1468,9 +1468,10 @@ func tableFormatOptionsFromConfig(cfg ui.ThemeConfigFile) formatter.TableFormatO
 		opts.ColumnHints = make(map[string]formatter.ColumnHint, len(schemaHints))
 		for k, h := range schemaHints {
 			opts.ColumnHints[k] = formatter.ColumnHint{
-				MaxWidth: h.MaxWidth,
-				Priority: h.Priority,
-				Align:    h.Align,
+				MaxWidth:    h.MaxWidth,
+				Priority:    h.Priority,
+				Align:       h.Align,
+				DisplayName: h.DisplayName,
 			}
 			if h.Hidden {
 				opts.HiddenColumns = append(opts.HiddenColumns, k)

--- a/examples/data/README.md
+++ b/examples/data/README.md
@@ -1,0 +1,81 @@
+# Example Data Files
+
+Sample data files for testing kvx features.
+
+## Schema Example: users.json + users_schema.json
+
+Demonstrates the `--schema` flag for customizing table column display.
+
+### Without schema (default)
+
+```bash
+kvx examples/data/users.json -o table
+```
+
+Output shows all columns with original field names:
+```
+╭─────────────────────────── kvx ────────────────────────────╮
+│#    department   full_name    internal_code  score  user_id│
+│────────────────────────────────────────────────────────────│
+│1    Engineering  Alice Smith  X123           95     u001   │
+│2    Sales        Bob Jones    Y456           87     u002   │
+│3    Engineering  Carol White  Z789           92     u003   │
+│4    Marketing    David Lee    W012           78     u004   │
+│5    Engineering  Eva Brown    V345           99     u005   │
+╰ _ ────────────────────────────────────────────── list: 1/5 ╯
+```
+
+### With schema
+
+```bash
+kvx examples/data/users.json --schema examples/data/users_schema.json -o table
+```
+
+Output with schema-driven display:
+```
+╭─────────────────────────── kvx ────────────────────────────╮
+│#    Dept         Name         Score  ID                    │
+│──────────────────────────────────────────                  │
+│1    Engineering  Alice Smith     95  u001                  │
+│2    Sales        Bob Jones       87  u002                  │
+│3    Engineering  Carol White     92  u003                  │
+│4    Marketing    David Lee       78  u004                  │
+│5    Engineering  Eva Brown       99  u005                  │
+╰ _ ────────────────────────────────────────────── list: 1/5 ╯
+```
+
+### What the schema does
+
+The [users_schema.json](users_schema.json) file applies these hints:
+
+| Field | Schema Setting | Effect |
+|-------|----------------|--------|
+| `user_id` | `"title": "ID"` | Column header renamed |
+| `full_name` | `"title": "Name"` | Column header renamed |
+| `department` | `"title": "Dept"` | Column header renamed |
+| `score` | `"type": "integer"` | Right-aligned |
+| `internal_code` | `"deprecated": true` | Column hidden |
+
+### Interactive mode
+
+```bash
+kvx examples/data/users.json --schema examples/data/users_schema.json -i
+```
+
+### With column ordering
+
+Combine `--schema` with config file column ordering:
+
+```yaml
+# ~/.config/kvx/config.yaml
+formatting:
+  table:
+    column_order: [full_name, user_id, score, department]
+```
+
+## Other data files
+
+- `sample_cluster.json` - Large nested cluster configuration
+- `sample_employees.csv` - CSV format example  
+- `sample_nested.json` - Nested JSON with encoded strings for auto-decode testing
+- `sample.jwt` - JWT token for decoding

--- a/examples/data/users.json
+++ b/examples/data/users.json
@@ -1,0 +1,7 @@
+[
+  {"user_id": "u001", "full_name": "Alice Smith", "score": 95, "internal_code": "X123", "department": "Engineering"},
+  {"user_id": "u002", "full_name": "Bob Jones", "score": 87, "internal_code": "Y456", "department": "Sales"},
+  {"user_id": "u003", "full_name": "Carol White", "score": 92, "internal_code": "Z789", "department": "Engineering"},
+  {"user_id": "u004", "full_name": "David Lee", "score": 78, "internal_code": "W012", "department": "Marketing"},
+  {"user_id": "u005", "full_name": "Eva Brown", "score": 99, "internal_code": "V345", "department": "Engineering"}
+]

--- a/examples/data/users_schema.json
+++ b/examples/data/users_schema.json
@@ -1,0 +1,36 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["user_id", "full_name"],
+    "properties": {
+      "user_id": {
+        "type": "string",
+        "title": "ID",
+        "description": "Unique user identifier",
+        "maxLength": 8
+      },
+      "full_name": {
+        "type": "string",
+        "title": "Name",
+        "description": "User's full name"
+      },
+      "score": {
+        "type": "integer",
+        "title": "Score",
+        "description": "Performance score (0-100)"
+      },
+      "department": {
+        "type": "string",
+        "title": "Dept",
+        "description": "Department name",
+        "enum": ["Engineering", "Sales", "Marketing", "Support"]
+      },
+      "internal_code": {
+        "type": "string",
+        "deprecated": true,
+        "description": "Legacy internal code - hidden from output"
+      }
+    }
+  }
+}

--- a/examples/schema_hints/README.md
+++ b/examples/schema_hints/README.md
@@ -1,0 +1,69 @@
+# Schema Hints Example
+
+Demonstrates how to customize table column display using JSON Schema or programmatic hints.
+
+## Features shown
+
+- Rename column headers (`title` → `DisplayName`)
+- Hide columns (`deprecated: true` → `Hidden`)
+- Cap column width (`maxLength` → `MaxWidth`)
+- Right-align numeric columns (`type: integer` → `Align: "right"`)
+- Explicit column ordering (`ColumnOrder`)
+
+## Run
+
+```bash
+go run ./examples/schema_hints
+```
+
+## Output
+
+```
+=== Table with JSON Schema hints ===
+(internal_code hidden via 'deprecated: true', headers renamed via 'title')
+
+╭─────────────── schema-example ───────────────╮
+│#    Name          ID      score              │
+│──────────────────────────────                │
+│1    Alice Smith   u001       95              │
+│2    Bob Jones     u002       87              │
+│3    Carol White   u003       92              │
+╰ _ ───────────────────────────────── list: 1/3╯
+```
+
+## Ways to provide hints
+
+### 1. JSON Schema file (CLI)
+
+```bash
+kvx data.json --schema schema.json
+```
+
+### 2. JSON Schema in code
+
+```go
+hints, _ := tui.ParseSchema(schemaJSON)
+tui.RenderTable(root, tui.TableOptions{ColumnHints: hints})
+```
+
+### 3. Programmatic hints
+
+```go
+hints := map[string]tui.ColumnHint{
+    "user_id": {DisplayName: "ID", MaxWidth: 10},
+    "score":   {Align: "right"},
+    "legacy":  {Hidden: true},
+}
+```
+
+## JSON Schema → ColumnHint mapping
+
+| JSON Schema Field | ColumnHint Field | Effect |
+|-------------------|------------------|--------|
+| `title` | `DisplayName` | Column header text |
+| `maxLength` | `MaxWidth` | Cap column width |
+| `enum` | `MaxWidth` | Longest enum value |
+| `format` (date, uuid, etc.) | `MaxWidth` | Auto-calculated width |
+| `type: integer/number` | `Align: "right"` | Right-align column |
+| `deprecated: true` | `Hidden: true` | Hide column |
+| `required` array | `Priority` | Boost shrink priority |

--- a/examples/schema_hints/main.go
+++ b/examples/schema_hints/main.go
@@ -1,0 +1,113 @@
+// Example: Using JSON Schema to customize table column display
+//
+// This example demonstrates how to use tui.ParseSchema and ColumnHints
+// to control column headers, widths, alignment, and visibility when
+// rendering tables with kvx as a library.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/oakwood-commons/kvx/pkg/core"
+	"github.com/oakwood-commons/kvx/pkg/tui"
+)
+
+func main() {
+	// Sample data: array of user objects
+	data := []map[string]any{
+		{"user_id": "u001", "full_name": "Alice Smith", "score": 95, "internal_code": "X123"},
+		{"user_id": "u002", "full_name": "Bob Jones", "score": 87, "internal_code": "Y456"},
+		{"user_id": "u003", "full_name": "Carol White", "score": 92, "internal_code": "Z789"},
+	}
+
+	root, err := core.LoadObject(data)
+	if err != nil {
+		log.Fatalf("failed to load data: %v", err)
+	}
+
+	// ====================================================================
+	// Option 1: Parse hints from a JSON Schema
+	// ====================================================================
+	schemaJSON := []byte(`{
+		"type": "array",
+		"items": {
+			"type": "object",
+			"required": ["user_id", "full_name"],
+			"properties": {
+				"user_id": {
+					"type": "string",
+					"title": "ID",
+					"maxLength": 8
+				},
+				"full_name": {
+					"type": "string",
+					"title": "Name"
+				},
+				"score": {
+					"type": "integer"
+				},
+				"internal_code": {
+					"type": "string",
+					"deprecated": true
+				}
+			}
+		}
+	}`)
+
+	hints, err := tui.ParseSchema(schemaJSON)
+	if err != nil {
+		log.Fatalf("failed to parse schema: %v", err)
+	}
+
+	fmt.Fprintln(os.Stdout, "=== Table with JSON Schema hints ===")                                       //nolint:forbidigo
+	fmt.Fprintln(os.Stdout, "(internal_code hidden via 'deprecated: true', headers renamed via 'title')") //nolint:forbidigo
+	fmt.Fprintln(os.Stdout)                                                                               //nolint:forbidigo
+	output := tui.RenderTable(root, tui.TableOptions{
+		AppName:     "schema-example",
+		Path:        "_",
+		Bordered:    true,
+		NoColor:     true,
+		ColumnOrder: []string{"full_name", "user_id", "score"}, // explicit order
+		ColumnHints: hints,
+	})
+	fmt.Fprintln(os.Stdout, output) //nolint:forbidigo
+
+	// ====================================================================
+	// Option 2: Build hints programmatically (no schema file needed)
+	// ====================================================================
+	programmaticHints := map[string]tui.ColumnHint{
+		"user_id":       {DisplayName: "User", MaxWidth: 6},
+		"full_name":     {DisplayName: "Full Name"},
+		"score":         {Align: "right"}, // right-align numeric column
+		"internal_code": {Hidden: true},   // hide this column
+	}
+
+	fmt.Fprintln(os.Stdout, "=== Table with programmatic hints ===")                  //nolint:forbidigo
+	fmt.Fprintln(os.Stdout, "(same result, built in Go code instead of JSON Schema)") //nolint:forbidigo
+	fmt.Fprintln(os.Stdout)                                                           //nolint:forbidigo
+	output2 := tui.RenderTable(root, tui.TableOptions{
+		AppName:     "programmatic",
+		Path:        "_",
+		Bordered:    true,
+		NoColor:     true,
+		ColumnOrder: []string{"full_name", "user_id", "score"},
+		ColumnHints: programmaticHints,
+	})
+	fmt.Fprintln(os.Stdout, output2) //nolint:forbidigo
+
+	// ====================================================================
+	// Without any hints (default behavior)
+	// ====================================================================
+	fmt.Fprintln(os.Stdout, "=== Table without hints (default) ===")   //nolint:forbidigo
+	fmt.Fprintln(os.Stdout, "(all columns shown with original names)") //nolint:forbidigo
+	fmt.Fprintln(os.Stdout)                                            //nolint:forbidigo
+	output3 := tui.RenderTable(root, tui.TableOptions{
+		AppName:  "default",
+		Path:     "_",
+		Bordered: true,
+		NoColor:  true,
+	})
+	fmt.Fprintln(os.Stdout, output3) //nolint:forbidigo
+}

--- a/internal/formatter/column_hint.go
+++ b/internal/formatter/column_hint.go
@@ -13,4 +13,8 @@ type ColumnHint struct {
 
 	// Align controls text alignment: "right" or "left" (default).
 	Align string
+
+	// DisplayName overrides the column header text.
+	// Empty string means use the original field name.
+	DisplayName string
 }

--- a/pkg/tui/panel_test.go
+++ b/pkg/tui/panel_test.go
@@ -29,3 +29,89 @@ func TestRenderDataPanel(t *testing.T) {
 		t.Fatalf("expected value kvx, got output: %q", out)
 	}
 }
+
+func TestRenderTable_ColumnarWithDisplayHints(t *testing.T) {
+	// Array of homogeneous objects — triggers columnar rendering
+	data := []any{
+		map[string]any{"user_id": "u001", "full_name": "Alice", "internal_code": "X123", "score": 95},
+		map[string]any{"user_id": "u002", "full_name": "Bob", "internal_code": "Y456", "score": 87},
+	}
+
+	hints := map[string]ColumnHint{
+		"user_id":       {DisplayName: "ID"},
+		"full_name":     {DisplayName: "Name"},
+		"internal_code": {Hidden: true},
+		"score":         {Align: "right"},
+	}
+
+	out := RenderTable(data, TableOptions{
+		NoColor:      true,
+		Width:        100,
+		ColumnarMode: "always",
+		ColumnHints:  hints,
+	})
+
+	t.Run("display names in header", func(t *testing.T) {
+		if !strings.Contains(out, "ID") {
+			t.Errorf("expected renamed header 'ID', got:\n%s", out)
+		}
+		if !strings.Contains(out, "Name") {
+			t.Errorf("expected renamed header 'Name', got:\n%s", out)
+		}
+	})
+
+	t.Run("hidden column excluded", func(t *testing.T) {
+		if strings.Contains(out, "internal_code") || strings.Contains(out, "X123") || strings.Contains(out, "Y456") {
+			t.Errorf("expected hidden column internal_code to be excluded, got:\n%s", out)
+		}
+	})
+
+	t.Run("data values present", func(t *testing.T) {
+		if !strings.Contains(out, "Alice") || !strings.Contains(out, "Bob") {
+			t.Errorf("expected data values, got:\n%s", out)
+		}
+	})
+
+	t.Run("right-aligned score", func(t *testing.T) {
+		lines := strings.Split(out, "\n")
+		found := false
+		for _, line := range lines {
+			if strings.Contains(line, "Bob") && strings.Contains(line, "87") {
+				idx := strings.Index(line, "87")
+				if idx > 0 && line[idx-1] == ' ' {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected right-aligned score column, got:\n%s", out)
+		}
+	})
+}
+
+func TestRenderTable_ColumnarMaxWidthWithDisplayName(t *testing.T) {
+	data := []any{
+		map[string]any{"name": "Very Long Name That Should Be Capped", "val": "ok"},
+		map[string]any{"name": "Another Long Name Here Too", "val": "ok"},
+	}
+
+	hints := map[string]ColumnHint{
+		"name": {DisplayName: "Full Name", MaxWidth: 10},
+	}
+
+	out := RenderTable(data, TableOptions{
+		NoColor:      true,
+		Width:        100,
+		ColumnarMode: "always",
+		ColumnHints:  hints,
+	})
+
+	// Header should use display name
+	if !strings.Contains(out, "Full Name") {
+		t.Errorf("expected 'Full Name' header, got:\n%s", out)
+	}
+	// Long values should be truncated by MaxWidth
+	if strings.Contains(out, "Very Long Name That Should Be Capped") {
+		t.Errorf("expected name to be capped by MaxWidth, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
fix(schema): support array schemas, fix width calculation, add docs

BREAKING CHANGE: None

Schema parsing:
- Fix ParseSchema to traverse into items.properties for array schemas
- Add DisplayName field to formatter.ColumnHint for title overrides
- Wire up DisplayName in columnar formatter header rendering

Width calculation:
- Add CalculateNaturalColumnarWidthWithHints function that:
  - Filters out hidden columns before width calculation
  - Uses DisplayName for header width when provided
  - Applies MaxWidth caps from schema hints
- Update renderColumnarBorderedTable to use the new function
- Fix resolveHints to key by display name for correct MaxWidth/Priority lookup
- Remove duplicate display-name remapping from TUI panel path

Tests:
- Add integration test TestCLI_SchemaAppliesColumnHints
- Add formatter tests for DisplayName, MaxWidth, alignment with hints
- Add TUI panel tests for columnar rendering with schema hints
- Add TestParseSchema_ArraySchema for array schema traversal

Documentation:
- Add "Column display hints (schema)" section to docs/library-usage.md
- Add array schema example and library cross-reference to docs/tui.md
- Create examples/schema_hints/ with runnable Go example
- Create examples/data/users.json and users_schema.json for CLI testing
- Add examples/data/README.md with usage instructions

The --schema flag now correctly processes JSON Schemas with type: "array"
by looking for properties in items.properties. Previously only top-level
object schemas worked. Table width now correctly reflects visible columns
with their display names and MaxWidth constraints applied.