### PR TITLE
feat(tui): add schema-driven display modes for interactive views

### DIFF
--- a/cmd/render_helpers.go
+++ b/cmd/render_helpers.go
@@ -16,5 +16,8 @@ func renderSnapshotOutput(cfg ui.ThemeConfigFile, renderRoot interface{}, root i
 	helpTitle, helpText := loadHelp(configPath, keyMode)
 	return renderSnapshotView(renderRoot, root, appName, helpTitle, helpText, startKeys, expr, noColor, sizing, func(m *ui.Model) {
 		applySnapshotConfigToModel(m, cfg)
+		if parsedDisplaySchema != nil {
+			m.DisplaySchema = parsedDisplaySchema
+		}
 	})
 }

--- a/examples/display_schema/README.md
+++ b/examples/display_schema/README.md
@@ -1,0 +1,56 @@
+# Display Schema Example
+
+This example demonstrates how to use **JSON Schema vendor extensions** (`x-kvx-*`)
+to give the kvx interactive TUI a rich, opinionated layout for your data.
+
+## The Problem
+
+By default, `kvx -i` renders every object as a flat KEY/VALUE table.
+For a catalog of infrastructure providers (the "scafctl" use case), you'd
+rather see:
+
+- **List view** — scrollable cards showing name, description, status badge,
+  version, and maintainer at a glance.
+- **Detail view** — a sectioned layout with an inline header, paragraph
+  description, colored tag pills, and a details table.
+
+## How It Works
+
+1. **providers.json** — an array of provider objects.
+2. **provider_schema.json** — a standard JSON Schema with `x-kvx-*` extensions
+   that describe the list and detail layouts.
+
+### x-kvx Extensions Used
+
+| Extension | Purpose |
+|-----------|---------|
+| `x-kvx-icon` | Emoji shown before the collection title |
+| `x-kvx-collectionTitle` | Heading above the list view |
+| `x-kvx-list` | Card-list configuration: title, subtitle, badges, secondary fields |
+| `x-kvx-detail` | Sectioned detail view: inline, paragraph, tags, table layouts |
+
+## Running
+
+```bash
+# Interactive TUI — card list + detail
+go run ./examples/display_schema
+
+# Non-interactive — prints the extracted schema info and a standard table
+go run ./examples/display_schema --snapshot
+```
+
+### CLI (from data files)
+
+```bash
+# Use --schema to point at the JSON Schema with x-kvx-* extensions
+kvx examples/display_schema/providers.json \
+    --schema examples/display_schema/provider_schema.json -i
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.go` | Entry point — loads data and schema, launches TUI |
+| `providers.json` | Sample data: 6 infrastructure providers |
+| `provider_schema.json` | JSON Schema with `x-kvx-*` display extensions |

--- a/examples/display_schema/main.go
+++ b/examples/display_schema/main.go
@@ -1,0 +1,107 @@
+// Example: Display schema for rich card-list and detail views
+//
+// This example demonstrates the "scafctl" use case — an infra-provider
+// catalog rendered with a scrollable card list and sectioned detail view
+// instead of the default flat KEY/VALUE table.
+//
+// Run interactively:
+//
+//	go run ./examples/display_schema
+//
+// Run as a snapshot (CI-safe):
+//
+//	go run ./examples/display_schema --snapshot
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/oakwood-commons/kvx/pkg/core"
+	"github.com/oakwood-commons/kvx/pkg/tui"
+)
+
+func main() {
+	// 1. Load the provider data
+	dataBytes, err := os.ReadFile("examples/display_schema/providers.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read providers.json: %v\n", err)
+		os.Exit(1)
+	}
+
+	var data any
+	if err := json.Unmarshal(dataBytes, &data); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse providers.json: %v\n", err)
+		os.Exit(1)
+	}
+
+	root, err := core.LoadObject(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load data: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 2. Load JSON Schema with x-kvx-* extensions
+	schemaBytes, err := os.ReadFile("examples/display_schema/provider_schema.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read provider_schema.json: %v\n", err)
+		os.Exit(1)
+	}
+
+	hints, displaySchema, err := tui.ParseSchemaWithDisplay(schemaBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 3. Show what was extracted
+	fmt.Println("=== Display Schema Extracted ===") //nolint:forbidigo
+	if displaySchema != nil {
+		fmt.Printf("  Icon:            %s\n", displaySchema.Icon)            //nolint:forbidigo
+		fmt.Printf("  CollectionTitle: %s\n", displaySchema.CollectionTitle) //nolint:forbidigo
+		if displaySchema.List != nil {
+			fmt.Printf("  List.TitleField: %s\n", displaySchema.List.TitleField)       //nolint:forbidigo
+			fmt.Printf("  List.SubtitleField: %s\n", displaySchema.List.SubtitleField) //nolint:forbidigo
+			fmt.Printf("  List.BadgeFields: %v\n", displaySchema.List.BadgeFields)     //nolint:forbidigo
+		}
+		if displaySchema.Detail != nil {
+			fmt.Printf("  Detail.TitleField: %s\n", displaySchema.Detail.TitleField)  //nolint:forbidigo
+			fmt.Printf("  Detail sections: %d\n", len(displaySchema.Detail.Sections)) //nolint:forbidigo
+		}
+		fmt.Println() //nolint:forbidigo
+	}
+
+	fmt.Printf("Column hints: %d fields recognized\n\n", len(hints)) //nolint:forbidigo
+
+	// 4. Render the standard table (for comparison)
+	fmt.Println("=== Standard Table Output ===") //nolint:forbidigo
+	tableOut := tui.RenderTable(root, tui.TableOptions{
+		AppName:     "display-schema-example",
+		Path:        "_",
+		Bordered:    true,
+		NoColor:     true,
+		ColumnHints: hints,
+	})
+	fmt.Println(tableOut) //nolint:forbidigo
+
+	// 5. Launch TUI with display schema (interactive)
+	//
+	// To run interactively:
+	//   go run ./examples/display_schema
+	//
+	// The TUI will show a card list with title, subtitle, and badges
+	// for each provider. Press Right/Enter to see the detail view
+	// with sectioned layout (inline header, description paragraph,
+	// tags, details table, dependencies).
+	//
+	// To run as a snapshot (non-interactive):
+	//   go run ./examples/display_schema --snapshot
+	cfg := tui.Config{
+		DisplaySchema: displaySchema,
+	}
+	if err := tui.Run(root, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/examples/display_schema/provider_schema.json
+++ b/examples/display_schema/provider_schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scafctl Provider Catalog",
+  "description": "Schema for an array of infrastructure providers managed by scafctl",
+  "type": "array",
+
+  "x-kvx-icon": "📦",
+  "x-kvx-collectionTitle": "Providers",
+
+  "x-kvx-list": {
+    "titleField": "name",
+    "subtitleField": "description",
+    "subtitleMaxLines": 2,
+    "badgeFields": ["status", "type"],
+    "secondaryFields": ["version", "maintainer"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "name",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["version", "type", "status"],
+        "layout": "inline"
+      },
+      {
+        "title": "Description",
+        "fields": ["description"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Tags",
+        "fields": ["tags"],
+        "layout": "tags"
+      },
+      {
+        "title": "Details",
+        "fields": ["maintainer", "lastUpdated", "resources"],
+        "layout": "table"
+      },
+      {
+        "title": "Dependencies",
+        "fields": ["dependencies"],
+        "layout": "tags"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["name", "version", "type", "status"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "title": "Provider",
+        "description": "Unique provider identifier"
+      },
+      "version": {
+        "type": "string",
+        "title": "Version",
+        "description": "Semantic version of the provider"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "Human-readable summary of the provider"
+      },
+      "type": {
+        "type": "string",
+        "title": "Type",
+        "enum": ["infrastructure", "data", "observability", "security"],
+        "description": "Category of the provider"
+      },
+      "status": {
+        "type": "string",
+        "title": "Status",
+        "enum": ["active", "beta", "deprecated"],
+        "description": "Lifecycle status of the provider"
+      },
+      "maintainer": {
+        "type": "string",
+        "title": "Maintainer",
+        "description": "Team responsible for the provider"
+      },
+      "tags": {
+        "type": "array",
+        "items": { "type": "string" },
+        "title": "Tags",
+        "description": "Classification tags"
+      },
+      "dependencies": {
+        "type": "array",
+        "items": { "type": "string" },
+        "title": "Dependencies",
+        "description": "Other providers this one depends on"
+      },
+      "lastUpdated": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Last Updated"
+      },
+      "resources": {
+        "type": "integer",
+        "title": "Resource Count",
+        "description": "Number of managed resources"
+      }
+    }
+  }
+}

--- a/examples/display_schema/providers.json
+++ b/examples/display_schema/providers.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "aws-ec2",
+    "version": "v3.12.1",
+    "description": "Amazon EC2 instances, security groups, and networking resources",
+    "type": "infrastructure",
+    "status": "active",
+    "maintainer": "platform-team",
+    "tags": ["cloud", "aws", "compute"],
+    "dependencies": ["aws-vpc", "aws-iam"],
+    "lastUpdated": "2024-11-15T08:30:00Z",
+    "resources": 42
+  },
+  {
+    "name": "aws-rds",
+    "version": "v2.8.0",
+    "description": "Amazon RDS databases with automated backups and read replicas",
+    "type": "data",
+    "status": "active",
+    "maintainer": "data-team",
+    "tags": ["cloud", "aws", "database"],
+    "dependencies": ["aws-vpc", "aws-iam", "aws-kms"],
+    "lastUpdated": "2024-10-28T14:22:00Z",
+    "resources": 18
+  },
+  {
+    "name": "gcp-gke",
+    "version": "v1.5.3",
+    "description": "Google Kubernetes Engine clusters with node pools and autoscaling",
+    "type": "infrastructure",
+    "status": "active",
+    "maintainer": "platform-team",
+    "tags": ["cloud", "gcp", "kubernetes"],
+    "dependencies": ["gcp-network", "gcp-iam"],
+    "lastUpdated": "2024-11-10T09:15:00Z",
+    "resources": 31
+  },
+  {
+    "name": "azure-aks",
+    "version": "v0.9.2",
+    "description": "Azure Kubernetes Service with virtual nodes and ACR integration",
+    "type": "infrastructure",
+    "status": "beta",
+    "maintainer": "platform-team",
+    "tags": ["cloud", "azure", "kubernetes"],
+    "dependencies": ["azure-vnet", "azure-identity"],
+    "lastUpdated": "2024-11-01T11:45:00Z",
+    "resources": 24
+  },
+  {
+    "name": "datadog-monitors",
+    "version": "v4.1.0",
+    "description": "Datadog monitors, dashboards, and alerting configuration",
+    "type": "observability",
+    "status": "active",
+    "maintainer": "sre-team",
+    "tags": ["monitoring", "alerting", "saas"],
+    "dependencies": [],
+    "lastUpdated": "2024-09-20T16:00:00Z",
+    "resources": 56
+  },
+  {
+    "name": "vault-secrets",
+    "version": "v2.3.1",
+    "description": "HashiCorp Vault secret engines, policies, and auth methods",
+    "type": "security",
+    "status": "active",
+    "maintainer": "security-team",
+    "tags": ["secrets", "security", "hashicorp"],
+    "dependencies": [],
+    "lastUpdated": "2024-11-12T07:10:00Z",
+    "resources": 15
+  }
+]

--- a/internal/ui/detail_view.go
+++ b/internal/ui/detail_view.go
@@ -1,0 +1,368 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	runewidth "github.com/mattn/go-runewidth"
+
+	"github.com/oakwood-commons/kvx/internal/formatter"
+)
+
+// DetailViewModel holds state for the sectioned detail rendering of a single object.
+type DetailViewModel struct {
+	Object    map[string]interface{} // The object being displayed
+	Sections  []renderedSection      // Pre-computed rendered sections
+	Title     string                 // Header title (from TitleField)
+	ScrollTop int                    // First visible line
+	Width     int                    // Available width
+	Height    int                    // Available height
+}
+
+// renderedSection is a pre-computed section of the detail view.
+type renderedSection struct {
+	Title  string   // Section heading (may be empty)
+	Lines  []string // Rendered lines
+	Layout string   // Layout type for reference
+}
+
+// buildDetailViewModel creates a DetailViewModel from an object using the display schema.
+func buildDetailViewModel(node interface{}, schema *DisplaySchema, width, height int) *DetailViewModel {
+	obj, ok := node.(map[string]interface{})
+	if !ok || schema == nil || schema.Detail == nil {
+		return nil
+	}
+
+	dv := &DetailViewModel{
+		Object: obj,
+		Width:  width,
+		Height: height,
+	}
+
+	// Resolve title
+	if schema.Detail.TitleField != "" {
+		dv.Title = formatter.Stringify(obj[schema.Detail.TitleField])
+	}
+
+	// Build hidden set
+	hiddenSet := make(map[string]bool, len(schema.Detail.HiddenFields))
+	for _, h := range schema.Detail.HiddenFields {
+		hiddenSet[h] = true
+	}
+	// Title field is also hidden from sections (it's in the header)
+	if schema.Detail.TitleField != "" {
+		hiddenSet[schema.Detail.TitleField] = true
+	}
+
+	// Track which fields are covered by explicit sections
+	covered := make(map[string]bool)
+	for _, s := range schema.Detail.Sections {
+		for _, f := range s.Fields {
+			covered[f] = true
+		}
+	}
+
+	contentWidth := width - 4
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+
+	// Render explicit sections
+	for _, s := range schema.Detail.Sections {
+		rs := renderDetailSection(obj, s, contentWidth, hiddenSet)
+		if len(rs.Lines) > 0 {
+			dv.Sections = append(dv.Sections, rs)
+		}
+	}
+
+	// Collect uncovered fields into an "Other" section
+	otherKeys := collectObjectKeys(obj, nil)
+	var otherFields []string
+	for _, k := range otherKeys {
+		if !covered[k] && !hiddenSet[k] {
+			otherFields = append(otherFields, k)
+		}
+	}
+	if len(otherFields) > 0 {
+		other := DetailSection{
+			Fields: otherFields,
+			Layout: DisplayLayoutTable,
+		}
+		rs := renderDetailSection(obj, other, contentWidth, hiddenSet)
+		if len(rs.Lines) > 0 {
+			dv.Sections = append(dv.Sections, rs)
+		}
+	}
+
+	return dv
+}
+
+// renderDetailSection renders a single section of the detail view.
+func renderDetailSection(obj map[string]interface{}, section DetailSection, width int, hidden map[string]bool) renderedSection {
+	rs := renderedSection{
+		Title:  section.Title,
+		Layout: section.Layout,
+	}
+
+	layout := section.Layout
+	if layout == "" {
+		layout = DisplayLayoutTable
+	}
+
+	switch layout {
+	case DisplayLayoutInline:
+		rs.Lines = renderInlineSection(obj, section.Fields, width, hidden)
+	case DisplayLayoutParagraph:
+		rs.Lines = renderParagraphSection(obj, section.Fields, width, hidden)
+	case DisplayLayoutTags:
+		rs.Lines = renderTagsSection(obj, section.Fields, width, hidden)
+	default: // table
+		rs.Lines = renderTableSection(obj, section.Fields, width, hidden)
+	}
+
+	return rs
+}
+
+// renderInlineSection renders fields as "value1 · value2 · value3".
+func renderInlineSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool) []string {
+	var parts []string
+	for _, f := range fields {
+		if hidden[f] {
+			continue
+		}
+		v := obj[f]
+		if v == nil {
+			continue
+		}
+		s := formatter.Stringify(v)
+		if s == "" {
+			continue
+		}
+		parts = append(parts, s)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	line := strings.Join(parts, " · ")
+	if runewidth.StringWidth(line) > width {
+		line = runewidth.Truncate(line, width-3, "...")
+	}
+	return []string{line}
+}
+
+// renderParagraphSection renders fields as wrapped text paragraphs.
+func renderParagraphSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool) []string {
+	var lines []string
+	for _, f := range fields {
+		if hidden[f] {
+			continue
+		}
+		v := obj[f]
+		if v == nil {
+			continue
+		}
+		text := formatter.Stringify(v)
+		if text == "" {
+			continue
+		}
+		wrapped := wrapAtWidth(text, width)
+		lines = append(lines, strings.Split(wrapped, "\n")...)
+	}
+	return lines
+}
+
+// renderTagsSection renders array fields as colored pill badges.
+func renderTagsSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool) []string {
+	th := CurrentTheme()
+	badgeStyle := lipgloss.NewStyle().
+		Foreground(th.HeaderFG).
+		Background(th.HeaderBG).
+		PaddingLeft(1).
+		PaddingRight(1)
+
+	var badges []string
+	for _, f := range fields {
+		if hidden[f] {
+			continue
+		}
+		val := obj[f]
+		switch v := val.(type) {
+		case []interface{}:
+			for _, elem := range v {
+				badges = append(badges, badgeStyle.Render(formatter.Stringify(elem)))
+			}
+		case string:
+			badges = append(badges, badgeStyle.Render(v))
+		default:
+			if val != nil {
+				badges = append(badges, badgeStyle.Render(formatter.Stringify(val)))
+			}
+		}
+	}
+	if len(badges) == 0 {
+		return nil
+	}
+
+	// Wrap badges into lines that fit within width
+	var lines []string
+	currentLine := ""
+	currentWidth := 0
+	for _, badge := range badges {
+		bw := runewidth.StringWidth(stripANSI(badge))
+		spaceNeeded := bw
+		if currentWidth > 0 {
+			spaceNeeded++ // space separator
+		}
+		if currentWidth+spaceNeeded > width && currentWidth > 0 {
+			lines = append(lines, currentLine)
+			currentLine = badge
+			currentWidth = bw
+		} else {
+			if currentWidth > 0 {
+				currentLine += " "
+				currentWidth++
+			}
+			currentLine += badge
+			currentWidth += bw
+		}
+	}
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+	return lines
+}
+
+// renderTableSection renders fields as KEY/VALUE rows.
+func renderTableSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool) []string {
+	th := CurrentTheme()
+	keyStyle := lipgloss.NewStyle().Foreground(th.KeyColor)
+	valStyle := lipgloss.NewStyle().Foreground(th.ValueColor)
+
+	// Find longest key for alignment
+	maxKeyLen := 0
+	for _, f := range fields {
+		if hidden[f] {
+			continue
+		}
+		if len(f) > maxKeyLen {
+			maxKeyLen = len(f)
+		}
+	}
+	if maxKeyLen > width/3 {
+		maxKeyLen = width / 3
+	}
+
+	var lines []string
+	for _, f := range fields {
+		if hidden[f] {
+			continue
+		}
+		v := obj[f]
+		if v == nil {
+			continue
+		}
+		key := f
+		if len(key) > maxKeyLen {
+			key = runewidth.Truncate(key, maxKeyLen, "…")
+		}
+		// Pad key to alignment width
+		key += strings.Repeat(" ", maxKeyLen-runewidth.StringWidth(key))
+
+		val := stringifyValue(v, width-maxKeyLen-3)
+		line := keyStyle.Render(key) + "  " + valStyle.Render(val)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// stringifyValue converts a value to a display string with width limiting.
+func stringifyValue(v interface{}, maxWidth int) string {
+	if maxWidth < 3 {
+		maxWidth = 3
+	}
+	switch val := v.(type) {
+	case []interface{}:
+		parts := make([]string, 0, len(val))
+		for _, elem := range val {
+			parts = append(parts, formatter.Stringify(elem))
+		}
+		s := "[" + strings.Join(parts, ", ") + "]"
+		if runewidth.StringWidth(s) > maxWidth {
+			s = runewidth.Truncate(s, maxWidth-3, "") + "..."
+		}
+		return s
+	case map[string]interface{}:
+		s := fmt.Sprintf("{%d keys}", len(val))
+		return s
+	default:
+		s := formatter.Stringify(v)
+		if runewidth.StringWidth(s) > maxWidth {
+			s = runewidth.Truncate(s, maxWidth-3, "") + "..."
+		}
+		return s
+	}
+}
+
+// renderDetailView renders the full detail view for the panel layout.
+func renderDetailView(dv *DetailViewModel, _ *DisplaySchema, noColor bool) string {
+	if dv == nil {
+		return "  (no data)"
+	}
+
+	th := CurrentTheme()
+	contentWidth := dv.Width - 4
+	_ = contentWidth // used by sections indirectly via dv.Width
+
+	var allLines []string
+
+	// Title header
+	if dv.Title != "" {
+		titleStyle := lipgloss.NewStyle().Bold(true)
+		if !noColor {
+			titleStyle = titleStyle.Foreground(th.KeyColor)
+		}
+		allLines = append(allLines, titleStyle.Render(dv.Title))
+	}
+
+	// Render sections
+	for _, sec := range dv.Sections {
+		// Blank line before section
+		allLines = append(allLines, "")
+
+		// Section title
+		if sec.Title != "" {
+			sectionStyle := lipgloss.NewStyle().Bold(true)
+			if !noColor {
+				sectionStyle = sectionStyle.Foreground(th.StatusColor)
+			}
+			allLines = append(allLines, sectionStyle.Render(sec.Title))
+		}
+
+		// Section content
+		allLines = append(allLines, sec.Lines...)
+	}
+
+	// Scrolling
+	totalLines := len(allLines)
+	visibleHeight := dv.Height - 2 // borders
+	if visibleHeight < 1 {
+		visibleHeight = 1
+	}
+
+	if dv.ScrollTop > totalLines-visibleHeight {
+		dv.ScrollTop = totalLines - visibleHeight
+	}
+	if dv.ScrollTop < 0 {
+		dv.ScrollTop = 0
+	}
+
+	endLine := dv.ScrollTop + visibleHeight
+	if endLine > totalLines {
+		endLine = totalLines
+	}
+
+	visible := allLines[dv.ScrollTop:endLine]
+
+	return strings.Join(visible, "\n")
+}

--- a/internal/ui/display_schema.go
+++ b/internal/ui/display_schema.go
@@ -1,0 +1,93 @@
+package ui
+
+// DisplaySchema controls how the interactive TUI renders arrays of objects.
+// When present, arrays matching the schema render as a scrollable card list
+// (title + subtitle + badges) instead of the default KEY/VALUE table, and
+// drilling into an item shows a sectioned detail view.
+type DisplaySchema struct {
+	// Version identifies the schema format. Use "v1".
+	Version string `json:"displaySchema,omitempty"`
+
+	// Icon is an optional emoji/symbol shown before the collection title.
+	Icon string `json:"icon,omitempty"`
+
+	// CollectionTitle is an optional heading shown above the list view
+	// (e.g., "Providers", "Services").
+	CollectionTitle string `json:"collectionTitle,omitempty"`
+
+	// List configures how an array of objects is rendered as a card list.
+	// When nil, the default KEY/VALUE table is used.
+	List *ListDisplayConfig `json:"list,omitempty"`
+
+	// Detail configures how a single object is rendered when drilling in
+	// from the list view. When nil, the default KEY/VALUE table is used.
+	Detail *DetailDisplayConfig `json:"detail,omitempty"`
+}
+
+// ListDisplayConfig controls the card-list rendering for arrays of objects.
+type ListDisplayConfig struct {
+	// TitleField is the object key whose value is shown as the card title (bold).
+	// Required for list view activation.
+	TitleField string `json:"titleField"`
+
+	// SubtitleField is the object key whose value is shown below the title (dimmed, truncated).
+	SubtitleField string `json:"subtitleField,omitempty"`
+
+	// SubtitleMaxLines limits how many lines the subtitle occupies (default: 1).
+	SubtitleMaxLines int `json:"subtitleMaxLines,omitempty"`
+
+	// BadgeFields lists object keys whose values are rendered as inline pills/tags
+	// next to or below the title. Array values are expanded into individual badges.
+	BadgeFields []string `json:"badgeFields,omitempty"`
+
+	// SecondaryFields lists object keys shown as small metadata below the subtitle.
+	SecondaryFields []string `json:"secondaryFields,omitempty"`
+
+	// ArrayStyle overrides the global --array-style for this list.
+	// Valid values: "index", "numbered", "bullet", "none".
+	ArrayStyle string `json:"arrayStyle,omitempty"`
+}
+
+// DetailDisplayConfig controls how a single object is rendered in detail view.
+type DetailDisplayConfig struct {
+	// TitleField is the object key whose value is shown as the detail header.
+	TitleField string `json:"titleField"`
+
+	// Sections defines ordered groups of fields with specific layouts.
+	// Fields not mentioned in any section are collected into a trailing
+	// "Other" section using the default table layout.
+	Sections []DetailSection `json:"sections,omitempty"`
+
+	// HiddenFields lists object keys that are excluded from the detail view entirely.
+	HiddenFields []string `json:"hiddenFields,omitempty"`
+}
+
+// DetailSection defines a group of fields rendered together with a specific layout.
+type DetailSection struct {
+	// Title is an optional heading shown above this section.
+	Title string `json:"title,omitempty"`
+
+	// Fields lists the object keys included in this section.
+	Fields []string `json:"fields"`
+
+	// Layout controls how the fields are rendered:
+	//   - "inline"    — key: value pairs on a single line (e.g., "v1.0.0 · data")
+	//   - "paragraph" — full-width wrapped text block
+	//   - "tags"      — colored pill badges (for arrays of strings)
+	//   - "table"     — standard KEY/VALUE table rows (default)
+	Layout string `json:"layout,omitempty"`
+}
+
+// Layout constants for DetailSection.
+const (
+	DisplayLayoutInline    = "inline"
+	DisplayLayoutParagraph = "paragraph"
+	DisplayLayoutTags      = "tags"
+	DisplayLayoutTable     = "table"
+)
+
+// ListPanelMode constants control the behaviour of the search panel in list view.
+const (
+	ListPanelModeSearch = "search" // Deep search across all fields, committed on Enter
+	ListPanelModeFilter = "filter" // Real-time title+subtitle filter
+)

--- a/internal/ui/display_view_test.go
+++ b/internal/ui/display_view_test.go
@@ -1,0 +1,491 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/kvx/internal/formatter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// buildListViewModel
+// ---------------------------------------------------------------------------
+
+func TestBuildListViewModel_Basic(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{"name": "alpha", "desc": "First", "status": "active"},
+		map[string]interface{}{"name": "beta", "desc": "Second", "status": "beta"},
+	}
+	schema := &DisplaySchema{
+		List: &ListDisplayConfig{
+			TitleField:    "name",
+			SubtitleField: "desc",
+			BadgeFields:   []string{"status"},
+		},
+	}
+
+	vm := buildListViewModel(data, schema, 80, 24)
+	require.NotNil(t, vm)
+	assert.Len(t, vm.Items, 2)
+	assert.Equal(t, "alpha", vm.Items[0].Title)
+	assert.Equal(t, "First", vm.Items[0].Subtitle)
+	assert.Equal(t, []string{"active"}, vm.Items[0].Badges)
+	assert.Equal(t, "beta", vm.Items[1].Title)
+}
+
+func TestBuildListViewModel_NilSchema(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{"name": "x"},
+	}
+	assert.Nil(t, buildListViewModel(data, nil, 80, 24))
+}
+
+func TestBuildListViewModel_NotArray(t *testing.T) {
+	schema := &DisplaySchema{List: &ListDisplayConfig{TitleField: "name"}}
+	assert.Nil(t, buildListViewModel("not an array", schema, 80, 24))
+}
+
+func TestBuildListViewModel_EmptyArray(t *testing.T) {
+	schema := &DisplaySchema{List: &ListDisplayConfig{TitleField: "name"}}
+	vm := buildListViewModel([]interface{}{}, schema, 80, 24)
+	require.NotNil(t, vm)
+	assert.Empty(t, vm.Items)
+}
+
+func TestBuildListViewModel_BadgeFromArray(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{
+			"name": "svc",
+			"tags": []interface{}{"cloud", "aws"},
+		},
+	}
+	schema := &DisplaySchema{
+		List: &ListDisplayConfig{
+			TitleField:  "name",
+			BadgeFields: []string{"tags"},
+		},
+	}
+	vm := buildListViewModel(data, schema, 80, 24)
+	require.NotNil(t, vm)
+	assert.Contains(t, vm.Items[0].Badges, "cloud")
+	assert.Contains(t, vm.Items[0].Badges, "aws")
+}
+
+func TestBuildListViewModel_SecondaryFields(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{
+			"name":    "alpha",
+			"version": "v1.2.3",
+			"owner":   "team-x",
+		},
+	}
+	schema := &DisplaySchema{
+		List: &ListDisplayConfig{
+			TitleField:      "name",
+			SecondaryFields: []string{"version", "owner"},
+		},
+	}
+	vm := buildListViewModel(data, schema, 80, 24)
+	require.NotNil(t, vm)
+	assert.Contains(t, vm.Items[0].Secondary, "v1.2.3")
+	assert.Contains(t, vm.Items[0].Secondary, "team-x")
+}
+
+// ---------------------------------------------------------------------------
+// renderListView
+// ---------------------------------------------------------------------------
+
+func TestRenderListView_ContainsTitles(t *testing.T) {
+	data := []interface{}{
+		map[string]interface{}{"name": "alpha", "desc": "First provider"},
+		map[string]interface{}{"name": "beta", "desc": "Second provider"},
+	}
+	schema := &DisplaySchema{
+		CollectionTitle: "Providers",
+		List: &ListDisplayConfig{
+			TitleField:    "name",
+			SubtitleField: "desc",
+		},
+	}
+	vm := buildListViewModel(data, schema, 60, 20)
+	require.NotNil(t, vm)
+	content := renderListView(vm, schema, false)
+	assert.Contains(t, content, "alpha")
+	assert.Contains(t, content, "beta")
+}
+
+func TestRenderListView_EmptyList(t *testing.T) {
+	schema := &DisplaySchema{
+		List: &ListDisplayConfig{TitleField: "name"},
+	}
+	vm := buildListViewModel([]interface{}{}, schema, 60, 20)
+	require.NotNil(t, vm)
+	content := renderListView(vm, schema, false)
+	assert.Contains(t, content, "empty")
+}
+
+// ---------------------------------------------------------------------------
+// filterListItems
+// ---------------------------------------------------------------------------
+
+func TestFilterListItems(t *testing.T) {
+	items := []ListViewItem{
+		{Index: 0, Title: "aws-ec2", Subtitle: "EC2 instances"},
+		{Index: 1, Title: "gcp-gke", Subtitle: "Kubernetes"},
+		{Index: 2, Title: "aws-rds", Subtitle: "Databases"},
+	}
+
+	lv := &ListViewModel{Items: items, Filter: "aws"}
+	filtered := filterListItems(lv)
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, "aws-ec2", filtered[0].Title)
+	assert.Equal(t, "aws-rds", filtered[1].Title)
+
+	lv.Filter = "kubernetes"
+	filtered2 := filterListItems(lv)
+	assert.Len(t, filtered2, 1)
+	assert.Equal(t, "gcp-gke", filtered2[0].Title)
+
+	lv.Filter = ""
+	all := filterListItems(lv)
+	assert.Len(t, all, 3)
+}
+
+// ---------------------------------------------------------------------------
+// isHomogeneousObjectArray
+// ---------------------------------------------------------------------------
+
+func TestIsHomogeneousObjectArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  interface{}
+		expect bool
+	}{
+		{"array of objects", []interface{}{
+			map[string]interface{}{"a": 1},
+			map[string]interface{}{"b": 2},
+		}, true},
+		{"empty array", []interface{}{}, false},
+		{"not array", "hello", false},
+		{"array of strings", []interface{}{"a", "b"}, false},
+		{"mixed array", []interface{}{
+			map[string]interface{}{"a": 1},
+			"string",
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, isHomogeneousObjectArray(tt.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectObjectKeys
+// ---------------------------------------------------------------------------
+
+func TestCollectObjectKeys(t *testing.T) {
+	obj := map[string]interface{}{"name": "a", "version": "v1", "secret": "x"}
+	keys := collectObjectKeys(obj, []string{"secret"})
+	assert.Contains(t, keys, "name")
+	assert.Contains(t, keys, "version")
+	assert.NotContains(t, keys, "secret")
+}
+
+// ---------------------------------------------------------------------------
+// wrapAtWidth
+// ---------------------------------------------------------------------------
+
+func TestWrapAtWidth(t *testing.T) {
+	// Short string stays on one line
+	result := wrapAtWidth("hello", 80)
+	assert.Equal(t, "hello", result)
+
+	// Long text wraps on word boundaries
+	long := "the quick brown fox jumps over the lazy dog and keeps on running"
+	wrapped := wrapAtWidth(long, 30)
+	lines := strings.Split(wrapped, "\n")
+	assert.Greater(t, len(lines), 1)
+}
+
+// ---------------------------------------------------------------------------
+// stringify
+// ---------------------------------------------------------------------------
+
+func TestStringify(t *testing.T) {
+	assert.Equal(t, "hello", formatter.Stringify("hello"))
+	assert.Equal(t, "42", formatter.Stringify(42))
+	assert.Equal(t, "3.14", formatter.Stringify(3.14))
+	assert.Equal(t, "true", formatter.Stringify(true))
+	assert.Equal(t, "", formatter.Stringify(nil))
+}
+
+// ---------------------------------------------------------------------------
+// buildDetailViewModel
+// ---------------------------------------------------------------------------
+
+func TestBuildDetailViewModel_Basic(t *testing.T) {
+	obj := map[string]interface{}{
+		"name":    "aws-ec2",
+		"version": "v3.12",
+		"desc":    "EC2 instances",
+		"tags":    []interface{}{"cloud", "aws"},
+	}
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Title: "", Fields: []string{"version"}, Layout: "inline"},
+				{Title: "Description", Fields: []string{"desc"}, Layout: "paragraph"},
+				{Title: "Tags", Fields: []string{"tags"}, Layout: "tags"},
+			},
+		},
+	}
+
+	dv := buildDetailViewModel(obj, schema, 60, 20)
+	require.NotNil(t, dv)
+	assert.Equal(t, "aws-ec2", dv.Title)
+	assert.Len(t, dv.Sections, 3)
+}
+
+func TestBuildDetailViewModel_NilSchema(t *testing.T) {
+	obj := map[string]interface{}{"name": "x"}
+	assert.Nil(t, buildDetailViewModel(obj, nil, 60, 20))
+}
+
+func TestBuildDetailViewModel_NotObject(t *testing.T) {
+	schema := &DisplaySchema{Detail: &DetailDisplayConfig{TitleField: "name"}}
+	assert.Nil(t, buildDetailViewModel("not an object", schema, 60, 20))
+}
+
+func TestBuildDetailViewModel_HiddenFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"name":   "test",
+		"secret": "hidden-value",
+		"public": "visible",
+	}
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField:   "name",
+			HiddenFields: []string{"secret"},
+			Sections: []DetailSection{
+				{Fields: []string{"public", "secret"}, Layout: "table"},
+			},
+		},
+	}
+
+	dv := buildDetailViewModel(obj, schema, 60, 20)
+	require.NotNil(t, dv)
+	// The rendered content should not contain "hidden-value"
+	content := renderDetailView(dv, schema, false)
+	assert.NotContains(t, content, "hidden-value")
+}
+
+// ---------------------------------------------------------------------------
+// renderDetailView
+// ---------------------------------------------------------------------------
+
+func TestRenderDetailView_ContainsSections(t *testing.T) {
+	obj := map[string]interface{}{
+		"name":    "test-svc",
+		"version": "v1.0",
+		"desc":    "A test service for unit tests",
+	}
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Title: "Info", Fields: []string{"version"}, Layout: "inline"},
+				{Title: "About", Fields: []string{"desc"}, Layout: "paragraph"},
+			},
+		},
+	}
+
+	dv := buildDetailViewModel(obj, schema, 60, 20)
+	require.NotNil(t, dv)
+	content := renderDetailView(dv, schema, false)
+	assert.Contains(t, content, "test-svc")
+	assert.Contains(t, content, "v1.0")
+	assert.Contains(t, content, "A test service for unit tests")
+}
+
+// ---------------------------------------------------------------------------
+// updateViewMode
+// ---------------------------------------------------------------------------
+
+func TestUpdateViewMode_ListMode(t *testing.T) {
+	m := &Model{
+		DisplaySchema: &DisplaySchema{
+			List: &ListDisplayConfig{TitleField: "name"},
+		},
+		WinWidth:  80,
+		WinHeight: 24,
+	}
+	data := []interface{}{
+		map[string]interface{}{"name": "a"},
+		map[string]interface{}{"name": "b"},
+	}
+	m.updateViewMode(data)
+	assert.Equal(t, "list", m.ViewMode)
+	assert.NotNil(t, m.ListViewState)
+}
+
+func TestUpdateViewMode_DefaultWhenNoSchema(t *testing.T) {
+	m := &Model{}
+	m.updateViewMode([]interface{}{map[string]interface{}{"a": 1}})
+	assert.Equal(t, "", m.ViewMode)
+	assert.Nil(t, m.ListViewState)
+}
+
+func TestUpdateViewMode_DefaultForScalar(t *testing.T) {
+	m := &Model{
+		DisplaySchema: &DisplaySchema{
+			List: &ListDisplayConfig{TitleField: "name"},
+		},
+	}
+	m.updateViewMode("just a string")
+	assert.Equal(t, "", m.ViewMode)
+}
+
+func TestUpdateViewMode_DetailAfterList(t *testing.T) {
+	m := &Model{
+		DisplaySchema: &DisplaySchema{
+			List:   &ListDisplayConfig{TitleField: "name"},
+			Detail: &DetailDisplayConfig{TitleField: "name"},
+		},
+		ViewMode:  "list",
+		WinWidth:  80,
+		WinHeight: 24,
+	}
+	obj := map[string]interface{}{"name": "drilled-in"}
+	m.updateViewMode(obj)
+	assert.Equal(t, "detail", m.ViewMode)
+	assert.NotNil(t, m.DetailViewState)
+}
+
+// ---------------------------------------------------------------------------
+// resolveViewAction — keymap mode tests
+// ---------------------------------------------------------------------------
+
+func TestResolveViewAction_ArrowKeysAllModes(t *testing.T) {
+	// Arrow keys must work in every mode.
+	for _, mode := range []KeyMode{KeyModeVim, KeyModeEmacs, KeyModeFunction} {
+		m := &Model{KeyMode: mode}
+		assert.Equal(t, VimActionUp, m.resolveViewAction("up"), "mode=%s up", mode)
+		assert.Equal(t, VimActionDown, m.resolveViewAction("down"), "mode=%s down", mode)
+		assert.Equal(t, VimActionBack, m.resolveViewAction("left"), "mode=%s left", mode)
+		assert.Equal(t, VimActionForward, m.resolveViewAction("right"), "mode=%s right", mode)
+		assert.Equal(t, VimActionEnter, m.resolveViewAction("enter"), "mode=%s enter", mode)
+		assert.Equal(t, VimActionQuit, m.resolveViewAction("ctrl+c"), "mode=%s ctrl+c", mode)
+		assert.Equal(t, VimActionHelp, m.resolveViewAction("f1"), "mode=%s f1", mode)
+		assert.Equal(t, VimActionTop, m.resolveViewAction("home"), "mode=%s home", mode)
+		assert.Equal(t, VimActionBottom, m.resolveViewAction("end"), "mode=%s end", mode)
+	}
+}
+
+func TestResolveViewAction_VimLetterKeys(t *testing.T) {
+	m := &Model{KeyMode: KeyModeVim}
+	assert.Equal(t, VimActionUp, m.resolveViewAction("k"))
+	assert.Equal(t, VimActionDown, m.resolveViewAction("j"))
+	assert.Equal(t, VimActionBack, m.resolveViewAction("h"))
+	assert.Equal(t, VimActionForward, m.resolveViewAction("l"))
+	assert.Equal(t, VimActionTop, m.resolveViewAction("g"))    // pending-g → top
+	assert.Equal(t, VimActionBottom, m.resolveViewAction("G")) //nolint:goconst
+	assert.Equal(t, VimActionHelp, m.resolveViewAction("?"))
+	assert.Equal(t, VimActionQuit, m.resolveViewAction("q"))
+	assert.Equal(t, VimActionSearch, m.resolveViewAction("/"))
+}
+
+func TestResolveViewAction_EmacsKeys(t *testing.T) {
+	m := &Model{KeyMode: KeyModeEmacs}
+	assert.Equal(t, VimActionUp, m.resolveViewAction("ctrl+p"))
+	assert.Equal(t, VimActionDown, m.resolveViewAction("ctrl+n"))
+	assert.Equal(t, VimActionBack, m.resolveViewAction("ctrl+b"))
+	assert.Equal(t, VimActionForward, m.resolveViewAction("ctrl+f"))
+	assert.Equal(t, VimActionQuit, m.resolveViewAction("ctrl+q"))
+	// Vim letter keys should NOT resolve in emacs mode.
+	assert.Equal(t, VimActionNone, m.resolveViewAction("j"))
+	assert.Equal(t, VimActionNone, m.resolveViewAction("k"))
+	assert.Equal(t, VimActionNone, m.resolveViewAction("h"))
+	assert.Equal(t, VimActionNone, m.resolveViewAction("l"))
+}
+
+func TestResolveViewAction_FunctionMode_NoLetterKeys(t *testing.T) {
+	m := &Model{KeyMode: KeyModeFunction}
+	// Single-letter keys must NOT resolve in function mode.
+	for _, key := range []string{"j", "k", "h", "l", "g", "G", "q", "?", "/"} {
+		assert.Equal(t, VimActionNone, m.resolveViewAction(key), "function mode: %q should be none", key)
+	}
+	// Ctrl+ keys from emacs should also be none.
+	for _, key := range []string{"ctrl+n", "ctrl+p", "ctrl+b", "ctrl+f"} {
+		assert.Equal(t, VimActionNone, m.resolveViewAction(key), "function mode: %q should be none", key)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleListViewKey — keymap mode integration
+// ---------------------------------------------------------------------------
+
+func listModel(mode KeyMode) *Model {
+	data := []interface{}{
+		map[string]interface{}{"name": "alpha"},
+		map[string]interface{}{"name": "beta"},
+		map[string]interface{}{"name": "gamma"},
+	}
+	schema := &DisplaySchema{List: &ListDisplayConfig{TitleField: "name"}}
+	return &Model{
+		KeyMode:       mode,
+		DisplaySchema: schema,
+		ViewMode:      "list",
+		Node:          data,
+		Path:          "_",
+		ListViewState: buildListViewModel(data, schema, 80, 24),
+		WinWidth:      80,
+		WinHeight:     24,
+	}
+}
+
+func TestListViewKey_VimNav(t *testing.T) {
+	m := listModel(KeyModeVim)
+	// j moves down
+	handled, _, _ := m.handleListViewKey("j")
+	assert.True(t, handled)
+	assert.Equal(t, 1, m.ListViewState.Selected)
+	// k moves up
+	handled, _, _ = m.handleListViewKey("k")
+	assert.True(t, handled)
+	assert.Equal(t, 0, m.ListViewState.Selected)
+}
+
+func TestListViewKey_EmacsNav(t *testing.T) {
+	m := listModel(KeyModeEmacs)
+	// ctrl+n moves down
+	handled, _, _ := m.handleListViewKey("ctrl+n")
+	assert.True(t, handled)
+	assert.Equal(t, 1, m.ListViewState.Selected)
+	// ctrl+p moves up
+	handled, _, _ = m.handleListViewKey("ctrl+p")
+	assert.True(t, handled)
+	assert.Equal(t, 0, m.ListViewState.Selected)
+	// vim "j" should NOT move — it becomes a filter character
+	m.ListViewState.Selected = 0
+	handled, _, _ = m.handleListViewKey("j")
+	assert.True(t, handled, "j should be handled as type-ahead filter in emacs mode")
+	assert.Equal(t, "j", m.ListViewState.Filter)
+}
+
+func TestListViewKey_FunctionMode_LettersFilter(t *testing.T) {
+	m := listModel(KeyModeFunction)
+	// In function mode, "j" should be a type-ahead filter character
+	handled, _, _ := m.handleListViewKey("j")
+	assert.True(t, handled)
+	assert.Equal(t, "j", m.ListViewState.Filter)
+	assert.Equal(t, 0, m.ListViewState.Selected)
+	// Arrow keys still work
+	m.ListViewState.Filter = ""
+	handled, _, _ = m.handleListViewKey("down")
+	assert.True(t, handled)
+	assert.Equal(t, 1, m.ListViewState.Selected)
+}

--- a/internal/ui/list_view.go
+++ b/internal/ui/list_view.go
@@ -1,0 +1,367 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	runewidth "github.com/mattn/go-runewidth"
+
+	"github.com/oakwood-commons/kvx/internal/formatter"
+)
+
+// ListViewModel holds state for the card-list rendering of an array of objects.
+type ListViewModel struct {
+	Items       []ListViewItem // Rendered items
+	Selected    int            // Currently selected index
+	ScrollTop   int            // First visible item index
+	Filter      string         // Active real-time filter text (title+subtitle)
+	SearchQuery string         // Committed deep-search query (all fields)
+	Width       int            // Available width
+	Height      int            // Available height (content rows)
+}
+
+// ListViewItem is a pre-computed renderable card derived from an object.
+type ListViewItem struct {
+	Index      int      // Original array index
+	Title      string   // Title text (from TitleField)
+	Subtitle   string   // Subtitle text (from SubtitleField)
+	Badges     []string // Badge labels (from BadgeFields)
+	Secondary  []string // Secondary field values (from SecondaryFields)
+	SearchText string   // Pre-computed concatenation of all field values for deep search
+}
+
+// buildListViewModel creates a ListViewModel from an array node using the display schema.
+func buildListViewModel(node interface{}, schema *DisplaySchema, width, height int) *ListViewModel {
+	arr, ok := node.([]interface{})
+	if !ok || schema == nil || schema.List == nil || schema.List.TitleField == "" {
+		return nil
+	}
+
+	items := make([]ListViewItem, 0, len(arr))
+	for i, elem := range arr {
+		obj, ok := elem.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		item := ListViewItem{Index: i}
+		item.Title = formatter.Stringify(obj[schema.List.TitleField])
+		if schema.List.SubtitleField != "" {
+			item.Subtitle = formatter.Stringify(obj[schema.List.SubtitleField])
+		}
+		for _, bf := range schema.List.BadgeFields {
+			val := obj[bf]
+			switch v := val.(type) {
+			case []interface{}:
+				for _, elem := range v {
+					item.Badges = append(item.Badges, formatter.Stringify(elem))
+				}
+			case string:
+				item.Badges = append(item.Badges, v)
+			default:
+				if val != nil {
+					item.Badges = append(item.Badges, formatter.Stringify(val))
+				}
+			}
+		}
+		for _, sf := range schema.List.SecondaryFields {
+			val := obj[sf]
+			if val != nil {
+				item.Secondary = append(item.Secondary, formatter.Stringify(val))
+			}
+		}
+
+		// Build SearchText from all field values for deep search.
+		var parts []string
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			parts = append(parts, formatter.Stringify(obj[k]))
+		}
+		item.SearchText = strings.Join(parts, " ")
+
+		items = append(items, item)
+	}
+
+	return &ListViewModel{
+		Items:  items,
+		Width:  width,
+		Height: height,
+	}
+}
+
+// filterListItems returns items matching the active filter and/or committed search query.
+// Filter matches title+subtitle (real-time). SearchQuery matches all fields (committed).
+func filterListItems(lv *ListViewModel) []ListViewItem {
+	if lv.Filter == "" && lv.SearchQuery == "" {
+		return lv.Items
+	}
+
+	result := make([]ListViewItem, 0, len(lv.Items))
+	for _, item := range lv.Items {
+		// Deep search: match against all field values.
+		if lv.SearchQuery != "" {
+			if !strings.Contains(strings.ToLower(item.SearchText), strings.ToLower(lv.SearchQuery)) {
+				continue
+			}
+		}
+		// Filter: match against title + subtitle only.
+		if lv.Filter != "" {
+			lower := strings.ToLower(lv.Filter)
+			if !strings.Contains(strings.ToLower(item.Title), lower) &&
+				!strings.Contains(strings.ToLower(item.Subtitle), lower) {
+				continue
+			}
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+// renderListView renders the card-list as a string that fits into the data panel.
+func renderListView(lv *ListViewModel, schema *DisplaySchema, noColor bool) string {
+	if lv == nil || len(lv.Items) == 0 {
+		return "  (empty)"
+	}
+
+	items := filterListItems(lv)
+	if len(items) == 0 {
+		return "  (no matches)"
+	}
+
+	th := CurrentTheme()
+	contentWidth := lv.Width - 4 // borders + padding
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+
+	// Compute lines per item to know how many fit on screen
+	subtitleLines := 1
+	if schema != nil && schema.List != nil && schema.List.SubtitleMaxLines > 0 {
+		subtitleLines = schema.List.SubtitleMaxLines
+	}
+	hasSecondary := schema != nil && schema.List != nil && len(schema.List.SecondaryFields) > 0
+	linesPerItem := 1 + subtitleLines // title + subtitle
+	if hasSecondary {
+		linesPerItem++ // secondary metadata line
+	}
+	if linesPerItem < 2 {
+		linesPerItem = 2
+	}
+	// Add blank line between items
+	linesPerItemWithGap := linesPerItem + 1
+
+	// Account for header lines (icon + collection title) when present
+	headerLines := 0
+	if schema != nil && (schema.Icon != "" || schema.CollectionTitle != "") {
+		headerLines = 3 // header, item count, blank line
+	}
+
+	// Ensure scroll window
+	availableHeight := lv.Height - headerLines
+	if availableHeight < linesPerItemWithGap {
+		availableHeight = linesPerItemWithGap
+	}
+	visibleCount := availableHeight / linesPerItemWithGap
+	if visibleCount < 1 {
+		visibleCount = 1
+	}
+
+	// Adjust scrollTop to keep selected visible
+	if lv.Selected < lv.ScrollTop {
+		lv.ScrollTop = lv.Selected
+	}
+	if lv.Selected >= lv.ScrollTop+visibleCount {
+		lv.ScrollTop = lv.Selected - visibleCount + 1
+	}
+	if lv.ScrollTop < 0 {
+		lv.ScrollTop = 0
+	}
+
+	// Styles
+	titleStyle := lipgloss.NewStyle().Bold(true)
+	subtitleStyle := lipgloss.NewStyle()
+	selectedMarker := lipgloss.NewStyle()
+	badgeStyle := lipgloss.NewStyle()
+	if !noColor {
+		titleStyle = titleStyle.Foreground(th.KeyColor)
+		subtitleStyle = subtitleStyle.Foreground(th.ValueColor)
+		selectedMarker = selectedMarker.Foreground(th.SelectedBG)
+		badgeStyle = badgeStyle.Foreground(th.HeaderFG).Background(th.HeaderBG)
+	}
+
+	var lines []string
+
+	// Header: icon + collection title
+	if schema != nil && (schema.Icon != "" || schema.CollectionTitle != "") {
+		header := ""
+		if schema.Icon != "" {
+			header = schema.Icon + " "
+		}
+		if schema.CollectionTitle != "" {
+			header += schema.CollectionTitle
+		}
+		lines = append(lines, "  "+strings.TrimSpace(header))
+		lines = append(lines, fmt.Sprintf("  %d items", len(items)))
+		lines = append(lines, "")
+	}
+
+	endIdx := lv.ScrollTop + visibleCount
+	if endIdx > len(items) {
+		endIdx = len(items)
+	}
+
+	for i := lv.ScrollTop; i < endIdx; i++ {
+		item := items[i]
+		isSelected := i == lv.Selected
+
+		// Selection indicator
+		marker := "  "
+		if isSelected {
+			if noColor {
+				marker = "│ "
+			} else {
+				marker = selectedMarker.Render("│") + " "
+			}
+		}
+
+		// Title line
+		title := item.Title
+		if title == "" {
+			title = fmt.Sprintf("[%d]", item.Index)
+		}
+		titleRendered := titleStyle.Render(title)
+
+		// Badges inline after title
+		badgeStr := ""
+		if len(item.Badges) > 0 {
+			badges := make([]string, 0, len(item.Badges))
+			for _, b := range item.Badges {
+				if noColor {
+					badges = append(badges, " "+b+" ")
+				} else {
+					badges = append(badges, badgeStyle.Render(" "+b+" "))
+				}
+			}
+			badgeStr = " " + strings.Join(badges, " ")
+		}
+
+		titleLine := marker + titleRendered + badgeStr
+		// Clamp to width
+		if runewidth.StringWidth(stripANSI(titleLine)) > contentWidth+2 {
+			titleLine = clampANSITextWidth(titleLine, contentWidth+2)
+		}
+		lines = append(lines, titleLine)
+
+		// Subtitle line(s)
+		if item.Subtitle != "" {
+			sub := item.Subtitle
+			maxSubWidth := contentWidth - 2 // account for marker indent
+			if maxSubWidth < 5 {
+				maxSubWidth = 5
+			}
+			// Wrap subtitle to subtitleLines
+			wrapped := wrapAtWidth(sub, maxSubWidth)
+			subLines := strings.Split(wrapped, "\n")
+			if len(subLines) > subtitleLines {
+				subLines = subLines[:subtitleLines]
+				// Add ellipsis to last line
+				last := subLines[len(subLines)-1]
+				if runewidth.StringWidth(last) > maxSubWidth-3 {
+					last = runewidth.Truncate(last, maxSubWidth-3, "") + "..."
+				} else {
+					last += "..."
+				}
+				subLines[len(subLines)-1] = last
+			}
+			for _, sl := range subLines {
+				rendered := subtitleStyle.Render(sl)
+				lines = append(lines, "  "+rendered)
+			}
+		}
+
+		// Secondary fields line
+		if len(item.Secondary) > 0 {
+			secondaryLine := "    " + subtitleStyle.Render(strings.Join(item.Secondary, " · "))
+			if runewidth.StringWidth(stripANSI(secondaryLine)) > contentWidth+2 {
+				secondaryLine = clampANSITextWidth(secondaryLine, contentWidth+2)
+			}
+			lines = append(lines, secondaryLine)
+		}
+
+		// Blank line between items
+		if i < endIdx-1 {
+			lines = append(lines, "")
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// wrapAtWidth wraps text at the given width, breaking on word boundaries.
+func wrapAtWidth(text string, width int) string {
+	if width <= 0 || runewidth.StringWidth(text) <= width {
+		return text
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return text
+	}
+
+	var lines []string
+	current := words[0]
+	for _, word := range words[1:] {
+		test := current + " " + word
+		if runewidth.StringWidth(test) > width {
+			lines = append(lines, current)
+			current = word
+		} else {
+			current = test
+		}
+	}
+	lines = append(lines, current)
+	return strings.Join(lines, "\n")
+}
+
+// listViewRowCount returns the number of displayable items (for footer label).
+func listViewRowCount(lv *ListViewModel) int {
+	if lv == nil {
+		return 0
+	}
+	return len(filterListItems(lv))
+}
+
+// isHomogeneousObjectArray checks if a node is an array where all elements are maps.
+func isHomogeneousObjectArray(node interface{}) bool {
+	arr, ok := node.([]interface{})
+	if !ok || len(arr) == 0 {
+		return false
+	}
+	for _, elem := range arr {
+		if _, ok := elem.(map[string]interface{}); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// collectObjectKeys returns sorted keys from a map, excluding hidden fields.
+func collectObjectKeys(obj map[string]interface{}, hidden []string) []string {
+	hiddenSet := make(map[string]bool, len(hidden))
+	for _, h := range hidden {
+		hiddenSet[h] = true
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		if !hiddenSet[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/ui/panel_layout_model.go
+++ b/internal/ui/panel_layout_model.go
@@ -130,13 +130,14 @@ func panelLayoutStateFromModel(m *Model, opts PanelLayoutModelOptions) PanelLayo
 		infoMessage = hint
 	}
 
-	return PanelLayoutState{
+	state := PanelLayoutState{
 		WinWidth:        m.WinWidth,
 		WinHeight:       m.WinHeight,
 		NoColor:         m.NoColor,
 		SnapshotHeader:  opts.SnapshotHeader,
 		DebugEnabled:    m.DebugMode,
-		AllowEditInput:  m.AllowEditInput,
+		AllowEditInput:  m.AllowEditInput && m.DisplaySchema == nil,
+		HideCopy:        m.DisplaySchema != nil,
 		HideFooter:      opts.HideFooter,
 		KeyMode:         m.KeyMode,
 		HelpVisible:     m.HelpVisible,
@@ -153,6 +154,7 @@ func panelLayoutStateFromModel(m *Model, opts PanelLayoutModelOptions) PanelLayo
 		ExprMode:        m.InputFocused,
 		ExprType:        m.ExprType,
 		SearchActive:    m.AdvancedSearchActive,
+		SearchTitle:     m.listSearchTitle(),
 		SearchResults:   searchResults,
 		MapFilterActive: m.MapFilterActive,
 		PaletteContent:  paletteContent(m),
@@ -163,6 +165,21 @@ func panelLayoutStateFromModel(m *Model, opts PanelLayoutModelOptions) PanelLayo
 		PathLabel:       pathLabel,
 		KeyColWidth:     m.KeyColWidth,
 	}
+
+	// Apply custom view mode content (list/detail views)
+	if customContent, ok := m.renderCustomViewContent(); ok {
+		state.CustomContent = customContent
+		if count, sel, label := m.customViewRowCount(); label != "" {
+			state.CustomFooterLabel = label
+			state.RowCount = count
+			state.SelectedRow = sel - 1
+		}
+		if pl := m.customViewPathLabel(); pl != "" {
+			state.PathLabel = pl
+		}
+	}
+
+	return state
 }
 
 func infoPopupText(m *Model) string {

--- a/internal/ui/run_model.go
+++ b/internal/ui/run_model.go
@@ -38,6 +38,8 @@ func RunModel(appName string, root interface{}, helpTitle, helpText string, debu
 	if configure != nil {
 		configure(&m)
 	}
+	// Trigger custom view mode detection (list/detail) now that DisplaySchema may be set.
+	m.updateViewMode(root)
 
 	// Eager auto-decode: recursively decode all serialized scalars at load time
 	if m.AllowDecode && m.AutoDecode == "eager" {

--- a/internal/ui/snapshot_model.go
+++ b/internal/ui/snapshot_model.go
@@ -50,6 +50,8 @@ func renderModelLayoutSnapshot(node interface{}, cfg ModelSnapshotConfig) string
 	if cfg.Configure != nil {
 		cfg.Configure(&m)
 	}
+	// Trigger custom view mode detection (list/detail) now that DisplaySchema may be set.
+	m.updateViewMode(node)
 	// Eager auto-decode: recursively decode all serialized scalars at load time
 	if m.AllowDecode && m.AutoDecode == "eager" {
 		m.Root = loader.RecursiveDecode(m.Root)

--- a/internal/ui/view_mode.go
+++ b/internal/ui/view_mode.go
@@ -1,0 +1,515 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// updateViewMode determines whether the current node should be rendered as a
+// list view, detail view, or the default table view based on the DisplaySchema.
+func (m *Model) updateViewMode(node interface{}) {
+	if m.DisplaySchema == nil {
+		m.ViewMode = ""
+		m.ListViewState = nil
+		m.DetailViewState = nil
+		return
+	}
+
+	// If we're coming from a list view drill-in, check for detail view
+	if m.ViewMode == "list" || m.ViewMode == "detail" {
+		// If the node is a single object and we have detail config, show detail
+		if _, isObj := node.(map[string]interface{}); isObj {
+			if m.DisplaySchema.Detail != nil {
+				m.ViewMode = "detail"
+				m.DetailViewState = buildDetailViewModel(node, m.DisplaySchema, m.WinWidth, m.WinHeight)
+				m.ListViewState = nil
+				return
+			}
+		}
+	}
+
+	// Check if node is a homogeneous array of objects for list view
+	if m.DisplaySchema.List != nil && m.DisplaySchema.List.TitleField != "" && isHomogeneousObjectArray(node) {
+		m.ViewMode = "list"
+		m.ListViewState = buildListViewModel(node, m.DisplaySchema, m.WinWidth, m.WinHeight)
+		m.DetailViewState = nil
+		return
+	}
+
+	// Default: table view
+	m.ViewMode = ""
+	m.ListViewState = nil
+	m.DetailViewState = nil
+}
+
+// resolveViewAction maps a raw keyStr to a VimAction, respecting the current KeyMode.
+// Arrow keys and universal keys (ctrl+c, enter, esc, f1, backspace) are always
+// resolved regardless of mode.  Mode-specific letter keys (j/k/h/l in vim,
+// ctrl+n/ctrl+p/ctrl+b/ctrl+f in emacs) are resolved through the binding maps.
+// In function mode only arrow keys, function keys, and universal keys are active.
+func (m *Model) resolveViewAction(keyStr string) VimAction {
+	// Universal keys first — always active in every mode.
+	switch keyStr {
+	case "up":
+		return VimActionUp
+	case "down":
+		return VimActionDown
+	case "left":
+		return VimActionBack
+	case "right":
+		return VimActionForward
+	case "enter":
+		return VimActionEnter
+	case "home":
+		return VimActionTop
+	case "end":
+		return VimActionBottom
+	case "ctrl+c":
+		return VimActionQuit
+	case "f1":
+		return VimActionHelp
+	}
+
+	// Mode-specific bindings.
+	switch m.KeyMode {
+	case KeyModeVim:
+		if a, ok := VimKeyBindings[keyStr]; ok {
+			// Map pending-g to Top for single-press in list view
+			if a == VimActionPendingG {
+				return VimActionTop
+			}
+			return a
+		}
+	case KeyModeEmacs:
+		if a, ok := EmacsKeyBindings[keyStr]; ok {
+			return a
+		}
+	case KeyModeFunction:
+		// Function mode: no single-letter shortcuts.
+		// Only F-keys are resolved (f1 already handled above).
+	}
+
+	return VimActionNone
+}
+
+// handleListViewKey handles key events when in list view mode.
+// Returns (handled bool, model, cmd).
+func (m *Model) handleListViewKey(keyStr string) (bool, tea.Model, tea.Cmd) {
+	if m.ViewMode != "list" || m.ListViewState == nil {
+		return false, m, nil
+	}
+
+	lv := m.ListViewState
+
+	// When the search panel is active, intercept navigation keys while
+	// letting text input fall through to handleSearchInput.
+	if m.AdvancedSearchActive {
+		// In filter mode, sync list filter in real-time from the query.
+		// In search mode, leave lv unchanged until Enter commits.
+		if m.ListPanelMode == ListPanelModeFilter {
+			lv.Filter = m.AdvancedSearchQuery
+			lv.Selected = 0
+			lv.ScrollTop = 0
+		}
+		items := filterListItems(lv)
+
+		switch keyStr {
+		case "esc":
+			// Close panel and discard the pending query.
+			m.AdvancedSearchActive = false
+			m.AdvancedSearchQuery = ""
+			m.SearchInput.SetValue("")
+			m.SearchInput.Blur()
+			if m.ListPanelMode == ListPanelModeFilter {
+				lv.Filter = ""
+			}
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			m.ListPanelMode = ""
+			return true, m, nil
+		case "enter":
+			// Commit and close the panel.
+			m.AdvancedSearchActive = false
+			m.SearchInput.Blur()
+			if m.ListPanelMode == ListPanelModeSearch {
+				// Deep search: commit query across all fields.
+				lv.SearchQuery = m.AdvancedSearchQuery
+				lv.Selected = 0
+				lv.ScrollTop = 0
+			}
+			// In filter mode, lv.Filter is already set above.
+			m.ListPanelMode = ""
+			return true, m, nil
+		case "up":
+			if lv.Selected > 0 {
+				lv.Selected--
+			}
+			return true, m, nil
+		case "down":
+			if len(items) > 0 && lv.Selected < len(items)-1 {
+				lv.Selected++
+			}
+			return true, m, nil
+		case "right":
+			// Drill into selected item and close search
+			if len(items) > 0 && lv.Selected < len(items) {
+				m.AdvancedSearchActive = false
+				m.SearchInput.Blur()
+				item := items[lv.Selected]
+				m.DetailSourcePath = m.Path
+				m.storeCursorForPath(m.Path)
+				newPath := buildPathWithKey(m.Path, fmt.Sprintf("[%d]", item.Index))
+				arr, ok := m.Node.([]interface{})
+				if !ok || item.Index >= len(arr) {
+					return true, m, nil
+				}
+				m.ViewMode = "detail"
+				newModel := m.NavigateTo(arr[item.Index], normalizePathForModel(newPath))
+				newModel.PathKeys = parsePathKeys(newModel.Path)
+				newModel.applyLayout(true)
+				return true, newModel, nil
+			}
+			return true, m, nil
+		case "ctrl+c":
+			return true, m, tea.Quit
+		default:
+			// Let all other keys (printable chars, backspace, etc.) fall
+			// through to handleSearchInput which manages the text input.
+			return false, m, nil
+		}
+	}
+
+	items := filterListItems(lv)
+
+	// Resolve the key through the keymap system.
+	action := m.resolveViewAction(keyStr)
+
+	// When the list is empty, only allow quit, help, esc (clear filter), and back.
+	if len(items) == 0 {
+		switch action { //nolint:exhaustive // only subset applies when list is empty
+		case VimActionQuit:
+			return true, m, tea.Quit
+		case VimActionHelp:
+			m.HelpVisible = !m.HelpVisible
+			m.applyLayout(true)
+			return true, m, nil
+		case VimActionBack:
+			if lv.Filter != "" {
+				lv.Filter = ""
+				lv.Selected = 0
+				lv.ScrollTop = 0
+				return true, m, nil
+			}
+			if lv.SearchQuery != "" {
+				lv.SearchQuery = ""
+				lv.Selected = 0
+				lv.ScrollTop = 0
+				return true, m, nil
+			}
+			result, cmd := m.navigateBack()
+			return true, result, cmd
+		default:
+			// other actions are not applicable when the list is empty
+		}
+		if keyStr == "esc" && (lv.Filter != "" || lv.SearchQuery != "") {
+			if lv.Filter != "" {
+				lv.Filter = ""
+			} else {
+				lv.SearchQuery = ""
+			}
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		return false, m, nil
+	}
+
+	switch action { //nolint:exhaustive // unhandled actions fall through to type-ahead filter
+	case VimActionUp:
+		if lv.Selected > 0 {
+			lv.Selected--
+		}
+		return true, m, nil
+
+	case VimActionDown:
+		if lv.Selected < len(items)-1 {
+			lv.Selected++
+		}
+		return true, m, nil
+
+	case VimActionTop:
+		lv.Selected = 0
+		lv.ScrollTop = 0
+		return true, m, nil
+
+	case VimActionBottom:
+		lv.Selected = len(items) - 1
+		return true, m, nil
+
+	case VimActionForward, VimActionEnter:
+		// Drill into the selected item
+		if lv.Selected < len(items) {
+			item := items[lv.Selected]
+			m.DetailSourcePath = m.Path
+			m.storeCursorForPath(m.Path)
+
+			newPath := buildPathWithKey(m.Path, fmt.Sprintf("[%d]", item.Index))
+			arr, ok := m.Node.([]interface{})
+			if !ok || item.Index >= len(arr) {
+				return true, m, nil
+			}
+			childNode := arr[item.Index]
+
+			// Force detail view mode before NavigateTo
+			m.ViewMode = "detail"
+			newModel := m.NavigateTo(childNode, normalizePathForModel(newPath))
+			newModel.PathKeys = parsePathKeys(newModel.Path)
+			newModel.applyLayout(true)
+			return true, newModel, nil
+		}
+		return true, m, nil
+
+	case VimActionBack:
+		// Clear filter first, then search, then navigate back.
+		if lv.Filter != "" {
+			lv.Filter = ""
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		if lv.SearchQuery != "" {
+			lv.SearchQuery = ""
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		// Navigate back to parent
+		result, cmd := m.navigateBack()
+		return true, result, cmd
+
+	case VimActionSearch:
+		// Open the search panel in search mode (deep search on Enter).
+		m.ListPanelMode = ListPanelModeSearch
+		m.AdvancedSearchActive = true
+		m.AdvancedSearchCommitted = false
+		m.AdvancedSearchQuery = ""
+		m.SearchInput.SetValue("")
+		m.SearchInput.SetCursor(0)
+		return true, m, m.SearchInput.Focus()
+
+	case VimActionFilter:
+		// Open the search panel in filter mode (real-time title+subtitle).
+		m.ListPanelMode = ListPanelModeFilter
+		m.AdvancedSearchActive = true
+		m.AdvancedSearchCommitted = false
+		m.AdvancedSearchQuery = lv.Filter
+		m.SearchInput.SetValue(lv.Filter)
+		m.SearchInput.SetCursor(len(lv.Filter))
+		return true, m, m.SearchInput.Focus()
+
+	case VimActionCopy, VimActionNextMatch, VimActionPrevMatch, VimActionClearSearch:
+		// No meaningful use in list view; consume to prevent fallthrough.
+		return true, m, nil
+
+	case VimActionQuit:
+		return true, m, tea.Quit
+
+	case VimActionHelp:
+		m.HelpVisible = !m.HelpVisible
+		m.applyLayout(true)
+		return true, m, nil
+	}
+
+	// esc always clears filter/search or navigates back, regardless of mode.
+	if keyStr == "esc" {
+		if lv.Filter != "" {
+			lv.Filter = ""
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		if lv.SearchQuery != "" {
+			lv.SearchQuery = ""
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		result, cmd := m.navigateBack()
+		return true, result, cmd
+	}
+
+	// Type-ahead filter: single printable rune (only when action is unresolved).
+	if action == VimActionNone {
+		if len(keyStr) == 1 && keyStr >= " " && keyStr <= "~" {
+			lv.Filter += keyStr
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+		// Backspace to remove filter character
+		if keyStr == "backspace" && lv.Filter != "" {
+			lv.Filter = lv.Filter[:len(lv.Filter)-1]
+			lv.Selected = 0
+			lv.ScrollTop = 0
+			return true, m, nil
+		}
+	}
+
+	return false, m, nil
+}
+
+// handleDetailViewKey handles key events when in detail view mode.
+// Returns (handled bool, model, cmd).
+func (m *Model) handleDetailViewKey(keyStr string) (bool, tea.Model, tea.Cmd) {
+	if m.ViewMode != "detail" || m.DetailViewState == nil {
+		return false, m, nil
+	}
+
+	dv := m.DetailViewState
+	action := m.resolveViewAction(keyStr)
+
+	switch action { //nolint:exhaustive // only navigation subset applies in detail view
+	case VimActionUp:
+		if dv.ScrollTop > 0 {
+			dv.ScrollTop--
+		}
+		return true, m, nil
+
+	case VimActionDown:
+		dv.ScrollTop++
+		return true, m, nil
+
+	case VimActionForward, VimActionEnter:
+		// Consume forward/enter as no-ops; the detail view is a read-only
+		// sectioned display — drilling deeper into raw fields is not useful.
+		return true, m, nil
+
+	case VimActionBack:
+		result, cmd := m.navigateBack()
+		return true, result, cmd
+
+	case VimActionTop:
+		dv.ScrollTop = 0
+		return true, m, nil
+
+	case VimActionSearch, VimActionFilter, VimActionNextMatch, VimActionPrevMatch, VimActionClearSearch:
+		// Not applicable in detail view; consume to prevent fallthrough.
+		return true, m, nil
+
+	case VimActionCopy:
+		// Copy not applicable in display schema detail view; consume.
+		return true, m, nil
+
+	case VimActionQuit:
+		return true, m, tea.Quit
+
+	case VimActionHelp:
+		m.HelpVisible = !m.HelpVisible
+		m.applyLayout(true)
+		return true, m, nil
+	}
+
+	// esc always navigates back, regardless of mode.
+	if keyStr == "esc" {
+		result, cmd := m.navigateBack()
+		return true, result, cmd
+	}
+
+	return false, m, nil
+}
+
+// renderCustomViewContent renders the content for list or detail view modes.
+// Returns the rendered string and true if a custom view was rendered, or ("", false) for default.
+func (m *Model) renderCustomViewContent() (string, bool) {
+	switch m.ViewMode {
+	case "list":
+		if m.ListViewState != nil {
+			// In filter mode, keep the filter in sync with the search panel query.
+			if m.AdvancedSearchActive && m.ListPanelMode == ListPanelModeFilter {
+				m.ListViewState.Filter = m.AdvancedSearchQuery
+			}
+			m.ListViewState.Width = m.WinWidth
+			m.ListViewState.Height = m.WinHeight - 6 // account for borders, footer, status
+			content := renderListView(m.ListViewState, m.DisplaySchema, m.NoColor)
+			return content, true
+		}
+	case "detail":
+		if m.DetailViewState != nil {
+			m.DetailViewState.Width = m.WinWidth
+			m.DetailViewState.Height = m.WinHeight - 6
+			content := renderDetailView(m.DetailViewState, m.DisplaySchema, m.NoColor)
+			return content, true
+		}
+	}
+	return "", false
+}
+
+// customViewRowCount returns the item count for the footer label in custom view modes.
+func (m *Model) customViewRowCount() (count int, selected int, label string) {
+	switch m.ViewMode {
+	case "list":
+		if m.ListViewState != nil {
+			// In filter mode, keep the filter in sync with the search panel query.
+			if m.AdvancedSearchActive && m.ListPanelMode == ListPanelModeFilter {
+				m.ListViewState.Filter = m.AdvancedSearchQuery
+			}
+			total := listViewRowCount(m.ListViewState)
+			sel := m.ListViewState.Selected + 1
+			if sel > total {
+				sel = total
+			}
+			filterSuffix := ""
+			if m.ListViewState.SearchQuery != "" {
+				filterSuffix += " /" + m.ListViewState.SearchQuery
+			}
+			if m.ListViewState.Filter != "" {
+				filterSuffix += " f:" + m.ListViewState.Filter
+			}
+			return total, sel, fmt.Sprintf("list: %d/%d%s", sel, total, filterSuffix)
+		}
+	case "detail":
+		return 1, 1, "detail"
+	}
+	return 0, 0, ""
+}
+
+// customViewPathLabel returns the path label for the footer in custom view modes.
+func (m *Model) customViewPathLabel() string {
+	switch m.ViewMode {
+	case "list":
+		if m.DisplaySchema != nil {
+			parts := []string{}
+			if m.DisplaySchema.Icon != "" {
+				parts = append(parts, m.DisplaySchema.Icon)
+			}
+			if m.DisplaySchema.CollectionTitle != "" {
+				parts = append(parts, m.DisplaySchema.CollectionTitle)
+			}
+			if len(parts) > 0 {
+				return strings.Join(parts, " ")
+			}
+		}
+		return formatPathForDisplay(m.Path)
+	case "detail":
+		if m.DetailViewState != nil && m.DetailViewState.Title != "" {
+			return m.DetailViewState.Title
+		}
+		return formatPathForDisplay(m.Path)
+	}
+	return ""
+}
+
+// listSearchTitle returns the panel title override for the search/filter panel
+// when a display schema list view is active.  Returns "" when no override is
+// needed (i.e. the default "Search" title should be used).
+func (m *Model) listSearchTitle() string {
+	if m.DisplaySchema == nil || m.ViewMode != "list" {
+		return ""
+	}
+	if m.ListPanelMode == ListPanelModeFilter {
+		return "Filter"
+	}
+	return "" // default "Search"
+}

--- a/pkg/tui/config.go
+++ b/pkg/tui/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	HelpNavigationDescriptions map[string]string // Custom help navigation descriptions (keys: "navigate_up_down", "navigate_back_forward", "go_to_key", "cycle_suggestions", "keys_cel_functions", "array_indices", "quit")
 	AllowDecode                *bool             // Whether Enter/Right can decode serialized scalars (default: true)
 	AutoDecode                 string            // Auto-decode mode: "" (manual only), "lazy" (on navigate), "eager" (at load)
+	DisplaySchema              *DisplaySchema    // Optional display schema for rich TUI rendering (list/detail views)
 }
 
 // DefaultConfig returns a baseline TUI config with the same defaults as the CLI.

--- a/pkg/tui/display_schema.go
+++ b/pkg/tui/display_schema.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/oakwood-commons/kvx/internal/ui"
+)
+
+// DisplaySchema controls how the interactive TUI renders arrays of objects.
+// When present, arrays matching the schema render as a scrollable card list
+// (title + subtitle + badges) instead of the default KEY/VALUE table, and
+// drilling into an item shows a sectioned detail view.
+//
+// A DisplaySchema can be:
+//   - constructed programmatically in Go code
+//   - parsed from a standalone JSON document via [ParseDisplaySchema]
+//   - extracted from JSON Schema vendor extensions (x-kvx-*) via [ParseSchemaWithDisplay]
+type DisplaySchema = ui.DisplaySchema
+
+// ListDisplayConfig controls the card-list rendering for arrays of objects.
+type ListDisplayConfig = ui.ListDisplayConfig
+
+// DetailDisplayConfig controls how a single object is rendered in detail view.
+type DetailDisplayConfig = ui.DetailDisplayConfig
+
+// DetailSection defines a group of fields rendered together with a specific layout.
+type DetailSection = ui.DetailSection
+
+// Layout constants for DetailSection.
+const (
+	DisplaySchemaLayoutInline    = ui.DisplayLayoutInline
+	DisplaySchemaLayoutParagraph = ui.DisplayLayoutParagraph
+	DisplaySchemaLayoutTags      = ui.DisplayLayoutTags
+	DisplaySchemaLayoutTable     = ui.DisplayLayoutTable
+)
+
+// ParseDisplaySchema parses a standalone display schema JSON document.
+// The document is identified by the presence of a "displaySchema" key.
+//
+// Example:
+//
+//	{
+//	  "displaySchema": "v1",
+//	  "icon": "📦",
+//	  "collectionTitle": "Providers",
+//	  "list": {
+//	    "titleField": "name",
+//	    "subtitleField": "description"
+//	  }
+//	}
+func ParseDisplaySchema(data []byte) (*DisplaySchema, error) {
+	// Quick check: is this a display schema doc?
+	var probe map[string]any
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("invalid display schema JSON: %w", err)
+	}
+	if _, ok := probe["displaySchema"]; !ok {
+		return nil, fmt.Errorf("missing \"displaySchema\" key: not a display schema document")
+	}
+
+	var ds DisplaySchema
+	if err := json.Unmarshal(data, &ds); err != nil {
+		return nil, fmt.Errorf("invalid display schema: %w", err)
+	}
+	if err := validateDisplaySchema(&ds); err != nil {
+		return nil, err
+	}
+	return &ds, nil
+}
+
+// extractDisplaySchemaFromJSONSchema extracts x-kvx-* vendor extensions from
+// an already-unmarshalled JSON Schema map. Returns nil when no extensions are present.
+func extractDisplaySchemaFromJSONSchema(raw map[string]any) *DisplaySchema {
+	// Find the right level: for type=array, look at the top level for x-kvx-* keys
+	target := raw
+	if typ, _ := raw["type"].(string); typ == "array" {
+		// x-kvx-* keys live on the array schema itself
+		target = raw
+	}
+
+	// Check for any x-kvx-* key
+	hasExtension := false
+	for k := range target {
+		if len(k) > 5 && k[:5] == "x-kvx" {
+			hasExtension = true
+			break
+		}
+	}
+	if !hasExtension {
+		return nil
+	}
+
+	ds := &DisplaySchema{Version: "v1"}
+
+	if icon, ok := target["x-kvx-icon"].(string); ok {
+		ds.Icon = icon
+	}
+	if title, ok := target["x-kvx-collectionTitle"].(string); ok {
+		ds.CollectionTitle = title
+	}
+
+	// x-kvx-list
+	if listRaw, ok := target["x-kvx-list"].(map[string]any); ok {
+		list := &ListDisplayConfig{}
+		if v, ok := listRaw["titleField"].(string); ok {
+			list.TitleField = v
+		}
+		if v, ok := listRaw["subtitleField"].(string); ok {
+			list.SubtitleField = v
+		}
+		if v, ok := listRaw["subtitleMaxLines"]; ok {
+			if n, ok := toInt(v); ok {
+				list.SubtitleMaxLines = n
+			}
+		}
+		if v, ok := listRaw["badgeFields"]; ok {
+			list.BadgeFields = extractStringArray(v)
+		}
+		if v, ok := listRaw["secondaryFields"]; ok {
+			list.SecondaryFields = extractStringArray(v)
+		}
+		if v, ok := listRaw["arrayStyle"].(string); ok {
+			list.ArrayStyle = v
+		}
+		ds.List = list
+	}
+
+	// x-kvx-detail
+	if detailRaw, ok := target["x-kvx-detail"].(map[string]any); ok {
+		detail := &DetailDisplayConfig{}
+		if v, ok := detailRaw["titleField"].(string); ok {
+			detail.TitleField = v
+		}
+		if v, ok := detailRaw["hiddenFields"]; ok {
+			detail.HiddenFields = extractStringArray(v)
+		}
+		if sectionsRaw, ok := detailRaw["sections"].([]any); ok {
+			for _, sRaw := range sectionsRaw {
+				sMap, ok := sRaw.(map[string]any)
+				if !ok {
+					continue
+				}
+				section := DetailSection{}
+				if v, ok := sMap["title"].(string); ok {
+					section.Title = v
+				}
+				if v, ok := sMap["fields"]; ok {
+					section.Fields = extractStringArray(v)
+				}
+				if v, ok := sMap["layout"].(string); ok {
+					section.Layout = v
+				}
+				detail.Sections = append(detail.Sections, section)
+			}
+		}
+		ds.Detail = detail
+	}
+
+	return ds
+}
+
+// validateDisplaySchema checks that a display schema has the minimum required fields.
+func validateDisplaySchema(ds *DisplaySchema) error {
+	if ds.List != nil && ds.List.TitleField == "" {
+		return fmt.Errorf("display schema: list.titleField is required")
+	}
+	if ds.Detail != nil {
+		for i, s := range ds.Detail.Sections {
+			if len(s.Fields) == 0 {
+				return fmt.Errorf("display schema: detail.sections[%d].fields is required", i)
+			}
+			switch s.Layout {
+			case "", DisplaySchemaLayoutInline, DisplaySchemaLayoutParagraph,
+				DisplaySchemaLayoutTags, DisplaySchemaLayoutTable:
+				// valid
+			default:
+				return fmt.Errorf("display schema: detail.sections[%d].layout: unknown layout %q", i, s.Layout)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/tui/display_schema_test.go
+++ b/pkg/tui/display_schema_test.go
@@ -1,0 +1,277 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ParseDisplaySchema (standalone document)
+// ---------------------------------------------------------------------------
+
+func TestParseDisplaySchema_Full(t *testing.T) {
+	doc := `{
+		"displaySchema": "v1",
+		"icon": "📦",
+		"collectionTitle": "Providers",
+		"list": {
+			"titleField": "name",
+			"subtitleField": "description",
+			"subtitleMaxLines": 2,
+			"badgeFields": ["status", "type"],
+			"secondaryFields": ["version", "maintainer"],
+			"arrayStyle": "bullet"
+		},
+		"detail": {
+			"titleField": "name",
+			"hiddenFields": ["internal_id"],
+			"sections": [
+				{
+					"title": "",
+					"fields": ["version", "type", "status"],
+					"layout": "inline"
+				},
+				{
+					"title": "Description",
+					"fields": ["description"],
+					"layout": "paragraph"
+				},
+				{
+					"title": "Tags",
+					"fields": ["tags"],
+					"layout": "tags"
+				},
+				{
+					"title": "Details",
+					"fields": ["maintainer", "resources"],
+					"layout": "table"
+				}
+			]
+		}
+	}`
+
+	ds, err := ParseDisplaySchema([]byte(doc))
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	assert.Equal(t, "v1", ds.Version)
+	assert.Equal(t, "📦", ds.Icon)
+	assert.Equal(t, "Providers", ds.CollectionTitle)
+
+	// List config
+	require.NotNil(t, ds.List)
+	assert.Equal(t, "name", ds.List.TitleField)
+	assert.Equal(t, "description", ds.List.SubtitleField)
+	assert.Equal(t, 2, ds.List.SubtitleMaxLines)
+	assert.Equal(t, []string{"status", "type"}, ds.List.BadgeFields)
+	assert.Equal(t, []string{"version", "maintainer"}, ds.List.SecondaryFields)
+	assert.Equal(t, "bullet", ds.List.ArrayStyle)
+
+	// Detail config
+	require.NotNil(t, ds.Detail)
+	assert.Equal(t, "name", ds.Detail.TitleField)
+	assert.Equal(t, []string{"internal_id"}, ds.Detail.HiddenFields)
+	require.Len(t, ds.Detail.Sections, 4)
+	assert.Equal(t, "inline", ds.Detail.Sections[0].Layout)
+	assert.Equal(t, "paragraph", ds.Detail.Sections[1].Layout)
+	assert.Equal(t, "tags", ds.Detail.Sections[2].Layout)
+	assert.Equal(t, "table", ds.Detail.Sections[3].Layout)
+}
+
+func TestParseDisplaySchema_Minimal(t *testing.T) {
+	doc := `{
+		"displaySchema": "v1",
+		"list": {
+			"titleField": "name"
+		}
+	}`
+
+	ds, err := ParseDisplaySchema([]byte(doc))
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+	assert.Equal(t, "name", ds.List.TitleField)
+	assert.Nil(t, ds.Detail)
+	assert.Empty(t, ds.Icon)
+}
+
+func TestParseDisplaySchema_MissingKey(t *testing.T) {
+	_, err := ParseDisplaySchema([]byte(`{"icon": "📦"}`))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "displaySchema")
+}
+
+func TestParseDisplaySchema_InvalidJSON(t *testing.T) {
+	_, err := ParseDisplaySchema([]byte(`not json`))
+	assert.Error(t, err)
+}
+
+func TestParseDisplaySchema_ListMissingTitleField(t *testing.T) {
+	doc := `{
+		"displaySchema": "v1",
+		"list": {
+			"subtitleField": "desc"
+		}
+	}`
+	_, err := ParseDisplaySchema([]byte(doc))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "titleField")
+}
+
+func TestParseDisplaySchema_InvalidLayout(t *testing.T) {
+	doc := `{
+		"displaySchema": "v1",
+		"detail": {
+			"titleField": "name",
+			"sections": [
+				{"fields": ["a"], "layout": "fancy"}
+			]
+		}
+	}`
+	_, err := ParseDisplaySchema([]byte(doc))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fancy")
+}
+
+func TestParseDisplaySchema_EmptySectionFields(t *testing.T) {
+	doc := `{
+		"displaySchema": "v1",
+		"detail": {
+			"titleField": "name",
+			"sections": [
+				{"fields": [], "layout": "table"}
+			]
+		}
+	}`
+	_, err := ParseDisplaySchema([]byte(doc))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fields")
+}
+
+// ---------------------------------------------------------------------------
+// ParseSchemaWithDisplay (JSON Schema with x-kvx-* extensions)
+// ---------------------------------------------------------------------------
+
+func TestParseSchemaWithDisplay_XKvxExtensions(t *testing.T) {
+	schema := `{
+		"type": "array",
+		"x-kvx-icon": "🔧",
+		"x-kvx-collectionTitle": "Services",
+		"x-kvx-list": {
+			"titleField": "name",
+			"subtitleField": "desc",
+			"badgeFields": ["status"]
+		},
+		"x-kvx-detail": {
+			"titleField": "name",
+			"sections": [
+				{"fields": ["desc"], "layout": "paragraph"},
+				{"fields": ["version", "status"], "layout": "inline"}
+			]
+		},
+		"items": {
+			"type": "object",
+			"required": ["name"],
+			"properties": {
+				"name": {"type": "string", "title": "Service Name"},
+				"desc": {"type": "string"},
+				"version": {"type": "string"},
+				"status": {"type": "string", "enum": ["active", "inactive"]}
+			}
+		}
+	}`
+
+	hints, ds, err := ParseSchemaWithDisplay([]byte(schema))
+	require.NoError(t, err)
+
+	// Column hints still work
+	require.NotEmpty(t, hints)
+	assert.Equal(t, "Service Name", hints["name"].DisplayName)
+	assert.Equal(t, 8, hints["status"].MaxWidth) // "inactive" = 8
+
+	// Display schema extracted
+	require.NotNil(t, ds)
+	assert.Equal(t, "🔧", ds.Icon)
+	assert.Equal(t, "Services", ds.CollectionTitle)
+	require.NotNil(t, ds.List)
+	assert.Equal(t, "name", ds.List.TitleField)
+	assert.Equal(t, "desc", ds.List.SubtitleField)
+	assert.Equal(t, []string{"status"}, ds.List.BadgeFields)
+	require.NotNil(t, ds.Detail)
+	require.Len(t, ds.Detail.Sections, 2)
+}
+
+func TestParseSchemaWithDisplay_NoExtensions(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"id": {"type": "integer"},
+			"name": {"type": "string"}
+		}
+	}`
+
+	hints, ds, err := ParseSchemaWithDisplay([]byte(schema))
+	require.NoError(t, err)
+	require.NotEmpty(t, hints)
+	assert.Nil(t, ds, "no x-kvx-* extensions → nil display schema")
+}
+
+func TestParseSchemaWithDisplay_BackwardCompatible(t *testing.T) {
+	// ParseSchema should still work and return same hints
+	schema := `{
+		"type": "object",
+		"required": ["id"],
+		"properties": {
+			"id": {"type": "integer"},
+			"label": {"type": "string", "maxLength": 20}
+		}
+	}`
+
+	hintsOld, err := ParseSchema([]byte(schema))
+	require.NoError(t, err)
+
+	hintsNew, ds, err := ParseSchemaWithDisplay([]byte(schema))
+	require.NoError(t, err)
+	assert.Nil(t, ds)
+	assert.Equal(t, hintsOld, hintsNew)
+}
+
+func TestParseSchemaWithDisplay_ObjectLevelExtensions(t *testing.T) {
+	// x-kvx-* on a type=object schema (not array)
+	schema := `{
+		"type": "object",
+		"x-kvx-icon": "👤",
+		"x-kvx-collectionTitle": "User",
+		"x-kvx-detail": {
+			"titleField": "fullName",
+			"sections": [
+				{"fields": ["email", "phone"], "layout": "table"}
+			]
+		},
+		"properties": {
+			"fullName": {"type": "string"},
+			"email": {"type": "string"},
+			"phone": {"type": "string"}
+		}
+	}`
+
+	_, ds, err := ParseSchemaWithDisplay([]byte(schema))
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+	assert.Equal(t, "👤", ds.Icon)
+	assert.Equal(t, "User", ds.CollectionTitle)
+	require.NotNil(t, ds.Detail)
+	assert.Equal(t, "fullName", ds.Detail.TitleField)
+}
+
+// ---------------------------------------------------------------------------
+// Layout constants
+// ---------------------------------------------------------------------------
+
+func TestDisplaySchemaLayoutConstants(t *testing.T) {
+	assert.Equal(t, "inline", DisplaySchemaLayoutInline)
+	assert.Equal(t, "paragraph", DisplaySchemaLayoutParagraph)
+	assert.Equal(t, "tags", DisplaySchemaLayoutTags)
+	assert.Equal(t, "table", DisplaySchemaLayoutTable)
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -157,6 +157,9 @@ func Run(root interface{}, cfg Config, opts ...tea.ProgramOption) error {
 		if cfg.AutoDecode != "" {
 			m.AutoDecode = cfg.AutoDecode
 		}
+		if cfg.DisplaySchema != nil {
+			m.DisplaySchema = cfg.DisplaySchema
+		}
 	}
 
 	return ui.RunModel(appName, root, helpTitle, helpText, cfg.DebugEnabled, cfg.DebugSink, cfg.InitialExpr, cfg.Width, cfg.Height, cfg.StartKeys, cfg.NoColor, cfg.ExprModeEntryHelp, cfg.FunctionHelpOverrides, configure, opts...)
@@ -223,6 +226,9 @@ func RenderSnapshot(root interface{}, cfg Config) string {
 		}
 		if cfg.AutoDecode != "" {
 			m.AutoDecode = cfg.AutoDecode
+		}
+		if cfg.DisplaySchema != nil {
+			m.DisplaySchema = cfg.DisplaySchema
 		}
 	}
 


### PR DESCRIPTION
Add support for x-kvx-* JSON Schema extensions that enable rich TUI rendering of structured data. When a display schema is provided via --schema, arrays of objects render as scrollable card lists instead of flat KEY/VALUE tables, and drilling into items shows sectioned detail views with multiple layout options.

Display schema features:
- x-kvx-list: Card list view with title, subtitle, badges, secondary fields
- x-kvx-detail: Sectioned detail view with inline, paragraph, tags, table layouts
- x-kvx-icon and x-kvx-collectionTitle: Collection-level metadata
- Non-interactive column projection via SelectColumns from list config

Key changes:
- Add DisplaySchema types and ParseDisplaySchema/ParseSchemaWithDisplay parsers
- Add list_view.go for card-list rendering with filtering and search
- Add detail_view.go for sectioned object display with multiple layouts
- Add view_mode.go for view state management and keymap-aware input handling
- Wire display schema through Config, CLI, and both Run/Snapshot paths
- Honor all three keymap profiles (vim/emacs/function) in custom views
- Disable expression mode when display schema is active (prevents view corruption)
- Remove copy action from display schema views (not applicable)
- Distinguish search (deep, on Enter) from filter (real-time, title+subtitle)

Includes embedded scafctl example demonstrating the provider list/detail use case with both programmatic and CLI-driven schema usage.

BREAKING CHANGE: None - fully backward compatible. Schemas without x-kvx-* extensions work exactly as before.

