### PR TITLE
feat(docs): add Hugo-based GitHub Pages documentation site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,84 @@
+name: Deploy Hugo Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "home/**"
+      - "assets/**"
+      - "layouts/**"
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: "0.158.0"
+    steps:
+      - name: Install Hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb \
+            https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: 'site/go.mod'
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            site/go.sum
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+          TZ: America/Chicago
+        run: |
+          cd site
+          hugo \
+            --gc \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ CHANGELOG-release.md
 # CodeQL local analysis
 .codeql-db/
 codeql-results.sarif
+
+# Hugo
+/public/
+/resources/_gen/
+.hugo_build.lock
+/site/.hugo_build.lock
+/site/resources/_gen/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/oakwood-commons/kvx)](https://github.com/oakwood-commons/kvx/releases)
 [![CI](https://github.com/oakwood-commons/kvx/actions/workflows/ci.yml/badge.svg)](https://github.com/oakwood-commons/kvx/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/oakwood-commons/kvx/graph/badge.svg)](https://codecov.io/gh/oakwood-commons/kvx)
+[![Documentation](https://img.shields.io/badge/docs-oakwood--commons.github.io%2Fkvx-blue)](https://oakwood-commons.github.io/kvx/)
 
 > **Alpha** — kvx is under active development. APIs and CLI flags may change between
 > releases. Breaking changes are documented in release notes. Questions? Open an

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,0 +1,2 @@
+/* Custom styles for kvx documentation site */
+/* Add site-specific CSS overrides here */

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Documentation"
+weight: 1
+bookCollapseSection: true
+---
+
+# kvx Documentation
+
+Welcome to the kvx documentation. Use the sidebar to navigate between sections.
+
+## Tutorials
+
+Step-by-step guides to get you productive with kvx:
+
+- [Getting Started](tutorials/getting-started/) — Installation, first run, and output formats
+- [Interactive Mode](tutorials/interactive-mode/) — Navigate, search, filter, and evaluate in the TUI
+- [CEL Expressions](tutorials/expressions/) — Dynamic querying and filtering with CEL
+- [Configuration & Themes](tutorials/configuration/) — Customize themes, keymaps, schemas, and shell completion
+
+## Reference
+
+- [TUI Quick Guide](tui/) — Panel layout, keybindings, snapshot mode, and debug
+- [Library Usage](library-usage/) — Use kvx as a Go library (`pkg/core` + `pkg/tui`)
+- [Embedding the TUI](embedding/) — Embed the interactive viewer in your own Go app
+- [Development](development/) — Build instructions, project structure, and architecture

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,8 @@
+---
+title: "Development"
+weight: 50
+---
+
 # Development
 
 ## Prerequisites

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,3 +1,8 @@
+---
+title: "Embedding the TUI"
+weight: 30
+---
+
 # Embedding kvx in another app
 
 Use the public `tui` and `core` packages to run kvx inside your Go program. This guide covers data loading, configuration, and common extension points.

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -1,3 +1,8 @@
+---
+title: "Library Usage"
+weight: 20
+---
+
 # Using kvx as a Library
 
 This guide covers everything you need to embed kvx in your own Go application — from a five-line quickstart to advanced customization.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,3 +1,8 @@
+---
+title: "TUI Quick Guide"
+weight: 10
+---
+
 # TUI quick guide
 
 ## Launch & sizing

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Tutorials"
+weight: 5
+bookCollapseSection: true
+---
+
+# Tutorials
+
+Step-by-step guides to help you get the most out of kvx.
+
+- [Getting Started](getting-started/) — Installation, first run, and output formats
+- [Interactive Mode](interactive-mode/) — Navigate, search, filter, and evaluate in the TUI
+- [CEL Expressions](expressions/) — Dynamic querying and filtering with CEL
+- [Configuration & Themes](configuration/) — Customize themes, keymaps, schemas, and shell completion

--- a/docs/tutorials/configuration.md
+++ b/docs/tutorials/configuration.md
@@ -1,0 +1,235 @@
+---
+title: "Configuration & Themes"
+weight: 4
+---
+
+# Configuration & Themes
+
+This tutorial covers configuring kvx, selecting themes, using schema-driven column hints, and setting up shell completion.
+
+## Config File
+
+kvx merges built-in defaults with your config file at `~/.config/kvx/config.yaml` (or `$XDG_CONFIG_HOME/kvx/config.yaml`). Override the config path with `--config-file`.
+
+### Viewing Configuration
+
+```bash
+# Show merged config (defaults + your overrides)
+kvx config get
+
+# Output as JSON, YAML, or table
+kvx config get -o json
+kvx config get -o yaml
+kvx config get -o table
+
+# Interactive TUI view
+kvx config get -i
+
+# Print merged config without reading input
+kvx --config
+```
+
+### Using a Specific Config File
+
+```bash
+kvx config get --config-file ~/.config/kvx/config.yaml
+kvx data.yaml --config-file /path/to/custom-config.yaml
+```
+
+## Themes
+
+Themes control the colors, borders, and styling of both TUI and CLI output.
+
+### Built-in Themes
+
+kvx includes four built-in themes:
+
+| Theme | Description |
+|-------|-------------|
+| `midnight` | Default theme, dark background |
+| `dark` | Alternative dark theme |
+| `warm` | Warm color palette |
+| `cool` | Cool/blue color palette |
+
+### Selecting a Theme
+
+```bash
+# Via CLI flag
+kvx data.yaml -i --theme warm
+
+# Via config file (ui.theme.default)
+# In ~/.config/kvx/config.yaml:
+#   ui:
+#     theme:
+#       default: warm
+```
+
+### Listing Available Themes
+
+```bash
+kvx config theme
+kvx config theme --config-file ~/.config/kvx/config.yaml
+```
+
+### Disabling Colors
+
+```bash
+kvx data.yaml --no-color
+```
+
+This removes colors and box-drawing borders for plain terminals and piping.
+
+## Schema-Driven Column Hints
+
+Use `--schema` to provide a JSON Schema file that controls how table columns are displayed.
+
+### How It Works
+
+kvx reads standard JSON Schema properties and derives display hints:
+
+| JSON Schema Field | Effect |
+|-------------------|--------|
+| `title` | Override column header text |
+| `maxLength` | Cap column width (characters) |
+| `enum` | Cap width to longest enum value |
+| `format` | Auto-width for known formats (date=10, uuid=36, email=40, etc.) |
+| `type: integer/number` | Right-align the column |
+| `deprecated: true` | Hide the column |
+| `required` array | Boost priority (+10) for required fields |
+| Property order | Priority tiebreaker (first declared = highest) |
+
+### Example Schema
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "name"],
+    "properties": {
+      "id": {
+        "title": "ID",
+        "type": "string",
+        "maxLength": 8
+      },
+      "name": {
+        "title": "Name",
+        "type": "string"
+      },
+      "score": {
+        "type": "integer"
+      },
+      "legacy_field": {
+        "deprecated": true
+      }
+    }
+  }
+}
+```
+
+### Usage
+
+```bash
+# CLI with schema
+kvx data.json --schema ./schema.json -o table
+
+# Interactive TUI with schema
+kvx data.json --schema ./schema.json -i
+```
+
+### Config File Schema Options
+
+You can also specify schemas in your config file:
+
+```yaml
+formatting:
+  table:
+    # Path to external schema file
+    schema_file: ./my-schema.json
+
+    # Or inline schema
+    schema:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          title: ID
+          maxLength: 8
+        name:
+          title: Name
+```
+
+**Priority**: CLI `--schema` > config `schema_file` > config inline `schema`.
+
+### Related Column Options
+
+```yaml
+formatting:
+  table:
+    column_order: [name, id, status]     # reorder columns
+    hidden_columns: [internal_id, hash]  # hide specific columns
+```
+
+## Keymaps
+
+kvx supports three keybinding modes:
+
+```bash
+kvx data.yaml -i --keymap vim       # default
+kvx data.yaml -i --keymap emacs
+kvx data.yaml -i --keymap function
+```
+
+Set the default in your config:
+
+```yaml
+ui:
+  features:
+    key_mode: emacs
+```
+
+## Shell Completion
+
+Generate shell completion scripts for your shell:
+
+### Bash
+
+```bash
+kvx completion bash > /etc/bash_completion.d/kvx
+```
+
+### Zsh
+
+```bash
+kvx completion zsh > "${fpath[1]}/_kvx"
+```
+
+### Fish
+
+```bash
+kvx completion fish > ~/.config/fish/completions/kvx.fish
+```
+
+### PowerShell
+
+```powershell
+kvx completion powershell | Out-String | Invoke-Expression
+```
+
+Restart your shell (or `source` the file) for completions to take effect. Zsh users must have `compinit` loaded before the completion file is sourced.
+
+## Array Index Style
+
+Control how array elements are labeled in output:
+
+```bash
+kvx data.yaml -e '_.items' --array-style none        # no indices (default)
+kvx data.yaml -e '_.items' --array-style index       # [0], [1]
+kvx data.yaml -e '_.items' --array-style numbered    # 1, 2
+kvx data.yaml -e '_.items' --array-style bullet      # •
+```
+
+## Next Steps
+
+- [TUI Quick Guide](../../tui/) — Complete keybinding reference and panel details
+- [Library Usage](../../library-usage/) — Use schemas and themes programmatically

--- a/docs/tutorials/expressions.md
+++ b/docs/tutorials/expressions.md
@@ -1,0 +1,181 @@
+---
+title: "CEL Expressions"
+weight: 3
+---
+
+# CEL Expressions
+
+kvx uses the [Common Expression Language (CEL)](https://cel.dev/) for dynamic querying, filtering, and transformation. This tutorial covers the expression syntax and common patterns.
+
+## Basics
+
+The root variable is always `_`. Use `-e` on the CLI or `:` in the TUI to evaluate expressions.
+
+```bash
+# Access a field
+kvx data.yaml -e '_.metadata.name'
+
+# Array index
+kvx data.yaml -e '_.items[0]'
+
+# Nested field access
+kvx data.yaml -e '_.items[0].name'
+```
+
+## Path Syntax
+
+kvx supports two path styles:
+
+### CLI (strict CEL)
+
+Use `_` as the root variable:
+
+```bash
+kvx data.yaml -e '_.metadata.created'
+kvx data.yaml -e '_.items[0]'
+kvx data.yaml -e 'type(_)'
+```
+
+### TUI (dotted-path shorthand)
+
+In the TUI expression mode, you can also use dotted-path shorthand:
+
+```
+metadata.created
+items[0]
+items.0
+items[0].name
+```
+
+The TUI automatically resolves dotted paths. For CEL functions, use the full `_`-rooted syntax.
+
+## Common Patterns
+
+### Field access
+
+```
+_.name                            # top-level field
+_.metadata.labels                 # nested field
+_.items[0].name                   # array element field
+```
+
+### Array operations
+
+```
+_.items[0]                        # first element
+_.items[2]                        # third element
+_.items.size()                    # array length
+```
+
+### Filtering
+
+```
+# Keep items where status is "running"
+_.items.filter(x, x.status == "running")
+
+# Keep items with replicas > 0
+_.items.filter(x, x.replicas > 0)
+
+# Combine conditions
+_.items.filter(x, x.status == "running" && x.replicas >= 2)
+```
+
+### Mapping / transformation
+
+```
+# Extract a single field from each item
+_.items.map(x, x.name)
+
+# Build a summary string
+_.items.map(x, x.name + ": " + string(x.replicas))
+```
+
+### Existence and type checking
+
+```
+# Check if a field exists
+has(_.metadata.labels)
+
+# Inspect the type
+type(_)
+type(_.items)
+type(_.items[0].replicas)
+```
+
+### String functions
+
+```
+_.name.startsWith("api")
+_.name.endsWith("-svc")
+_.name.contains("web")
+_.description.matches("v[0-9]+")
+```
+
+### Conditional expressions
+
+```
+_.replicas > 5 ? "high" : "low"
+has(_.labels) ? _.labels : {}
+```
+
+### Size and counting
+
+```
+_.items.size()                    # number of items
+_.name.size()                     # string length
+_.items.filter(x, x.status == "running").size()  # count matching
+```
+
+## Shell Quoting
+
+When using expressions with special characters on the command line, prefer single quotes around the entire expression:
+
+```bash
+# Single quotes (recommended)
+kvx data.yaml -e '_.items[0]'
+kvx data.yaml -e 'type(_)'
+kvx data.yaml -e '_.metadata["bad-key"]'
+
+# Double quotes require escaping
+kvx data.yaml -e "_.metadata[\"bad-key\"]"
+```
+
+### Tips
+
+- Use single quotes to avoid shell expansion of `$`, `!`, `*`, etc.
+- Bracket notation (`["key"]`) handles keys with hyphens, dots, or spaces.
+- In PowerShell, use double quotes with backtick escaping or single quotes.
+
+## Combining with Output Formats
+
+Expressions work with any output format:
+
+```bash
+# Filter and output as JSON
+kvx data.yaml -e '_.items.filter(x, x.status == "running")' -o json
+
+# Map names and output as YAML
+kvx data.yaml -e '_.items.map(x, x.name)' -o yaml
+
+# First item as a list
+kvx data.yaml -e '_.items[0]' -o list
+
+# Tree view of metadata
+kvx data.yaml -e '_.metadata' -o tree
+```
+
+## Expressions in the TUI
+
+In interactive mode, press `:` to enter expression mode:
+
+1. The input is prefilled with the current `_`-rooted path
+2. **Tab/Shift+Tab** cycle through keys and indices as completions
+3. **Up/Down** cycle through CEL functions valid for the current node type
+4. **Right** accepts the ghosted completion
+5. **Enter** evaluates and stays in expression mode
+6. **Esc** exits; non-navigable results fall back to the prior path
+
+## Next Steps
+
+- [Configuration & Themes](../configuration/) — Customize kvx to your workflow
+- [Library Usage](../../library-usage/) — Use CEL expressions programmatically with `core.Engine`

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,192 @@
+---
+title: "Getting Started"
+weight: 1
+---
+
+# Getting Started with kvx
+
+This tutorial walks you through installing kvx, loading your first data file, and exploring the output formats.
+
+## Installation
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew install oakwood-commons/tap/kvx
+```
+
+### From Source
+
+```bash
+go install github.com/oakwood-commons/kvx@latest
+```
+
+### From Release Binaries
+
+Download the latest binary for your platform from [GitHub Releases](https://github.com/oakwood-commons/kvx/releases), extract it, and add it to your `PATH`.
+
+**macOS note:** You may need to remove the quarantine attribute:
+
+```bash
+xattr -dr 'com.apple.quarantine' /usr/local/bin/kvx
+```
+
+## First Run
+
+Create a sample file `data.yaml`:
+
+```yaml
+metadata:
+  name: my-app
+  version: "2.1.0"
+items:
+  - name: api
+    status: running
+    replicas: 3
+  - name: web
+    status: running
+    replicas: 2
+  - name: worker
+    status: stopped
+    replicas: 0
+```
+
+Render it as a table:
+
+```bash
+kvx data.yaml
+```
+
+This produces a bordered table showing the top-level keys and values. Maps display as KEY/VALUE rows, and arrays of objects render as columnar tables with field-name headers.
+
+## Output Formats
+
+kvx supports multiple output formats via the `-o` flag:
+
+### Table (default)
+
+```bash
+kvx data.yaml
+kvx data.yaml -e '_.items' -o table
+```
+
+Tables auto-detect arrays of objects and render them as multi-column tables. Scalars print as raw values.
+
+### JSON
+
+```bash
+kvx data.yaml -o json
+kvx data.yaml -e '_.metadata' -o json
+```
+
+### YAML
+
+```bash
+kvx data.yaml -o yaml
+```
+
+### List
+
+```bash
+kvx data.yaml -e '_.items' -o list
+```
+
+List format displays each property on its own line. Arrays show each element with an index header (`[0]`, `[1]`, etc.) and indented properties.
+
+### Tree
+
+```bash
+kvx data.yaml -o tree
+```
+
+Tree output renders data as an ASCII tree using box-drawing characters. Control depth with `--tree-depth N` and hide values with `--tree-no-values`.
+
+### Mermaid
+
+```bash
+kvx data.yaml -o mermaid
+```
+
+Generates Mermaid flowchart syntax for visualization in Markdown. Use `--mermaid-direction TD|LR|BT|RL` to set flow direction.
+
+### CSV
+
+```bash
+kvx data.yaml -e '_.items' -o csv
+```
+
+Arrays of objects become rows with merged headers.
+
+## Basic Expressions
+
+Use `-e` (or `--expression`) to evaluate [CEL](https://cel.dev/) expressions against your data. The root variable is `_`:
+
+```bash
+# Access a field
+kvx data.yaml -e '_.metadata.name'
+
+# Array index
+kvx data.yaml -e '_.items[0]'
+
+# Nested field
+kvx data.yaml -e '_.items[0].name'
+
+# Output as JSON
+kvx data.yaml -e '_.metadata' -o json
+```
+
+See the [CEL Expressions tutorial](../expressions/) for advanced patterns like filtering, mapping, and type introspection.
+
+## Interactive Mode
+
+Launch the interactive TUI with `-i`:
+
+```bash
+kvx data.yaml -i
+```
+
+This opens a full-screen terminal interface where you can navigate, search, filter, and evaluate expressions. See the [Interactive Mode tutorial](../interactive-mode/) for a complete guide.
+
+For a one-shot render of the TUI layout (useful for scripting or CI):
+
+```bash
+kvx data.yaml --snapshot
+```
+
+## Input Formats
+
+kvx auto-detects the input format:
+
+| Format | Detection |
+|--------|-----------|
+| JSON | Content-based |
+| YAML | Content-based (single or multi-document) |
+| NDJSON | Content-based (newline-delimited JSON) |
+| TOML | By `.toml` extension or content |
+| CSV | By `.csv` extension or stdin shape |
+| JWT | Content-based (base64 dot-separated) |
+
+If no input is provided, kvx shows help. With `--expression` but no input, it evaluates against an empty object `{}`.
+
+## Limiting Records
+
+Control how many records are displayed:
+
+```bash
+# First 5 records
+kvx data.yaml -e '_.items' --limit 5
+
+# Skip first 2, then show next 5
+kvx data.yaml -e '_.items' --offset 2 --limit 5
+
+# Last 3 records
+kvx data.yaml -e '_.items' --tail 3
+```
+
+`--tail` ignores `--offset` and cannot be combined with `--limit`.
+
+## Next Steps
+
+- [Interactive Mode](../interactive-mode/) — Learn to navigate, search, and evaluate in the TUI
+- [CEL Expressions](../expressions/) — Advanced querying patterns
+- [Configuration & Themes](../configuration/) — Customize kvx

--- a/docs/tutorials/interactive-mode.md
+++ b/docs/tutorials/interactive-mode.md
@@ -1,0 +1,152 @@
+---
+title: "Interactive Mode"
+weight: 2
+---
+
+# Interactive Mode
+
+The interactive TUI lets you navigate, search, filter, and evaluate expressions against your data in a full-screen terminal interface.
+
+## Launching the TUI
+
+```bash
+kvx data.yaml -i
+```
+
+Override terminal size detection:
+
+```bash
+kvx data.yaml -i --width 120 --height 40
+```
+
+## Panels
+
+The TUI is organized into panels:
+
+- **Data panel** — Main table view. The bottom border shows the current CEL path (tail is kept when the path is long). The lower-right corner shows `n/x` for selection/visible rows.
+- **Input panel** — Single-line bordered input. Title reflects the current mode (Expression or Search). Hidden until activated.
+- **Info panel** — One row, borderless. Right-justified when input is hidden. Left-justified and recolored when input is shown.
+- **Footer** — Always visible. Left shows `? - Help`, right shows rows/cols.
+- **Help popup** — Hidden by default. Press `?` to toggle help content.
+
+## Navigation
+
+kvx defaults to **vim** keybindings:
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate up/down |
+| `h` / `l` | Navigate back/forward (ascend/drill) |
+| `/` | Search mode (live search keys/values) |
+| `n` / `N` | Next/previous search match |
+| `f` | Filter current map keys |
+| `gg` / `G` | Go to top/bottom |
+| `:` | Expression mode (CEL) |
+| `y` | Copy current path/expression |
+| `?` | Toggle help panel |
+| `q` | Quit |
+| `Esc` | Close input/help/search context (does not quit) |
+
+### Emacs keybindings
+
+```bash
+kvx data.yaml -i --keymap emacs
+```
+
+### Function-key keybindings
+
+```bash
+kvx data.yaml -i --keymap function
+```
+
+## Filter (Type-Ahead)
+
+With input hidden, typing letters, digits, or spaces filters rows by key prefix (case-insensitive):
+
+- **Backspace** edits the filter
+- **Esc** clears the filter
+- Navigation works on filtered rows
+- The `n/x` indicator reflects filtered counts
+- Filter clears automatically when you drill into or ascend from a node
+
+## Search
+
+Press `/` to enter search mode:
+
+- Type your query in the input bar — the query updates as you type but the deep search executes when you press **Enter**
+- **Enter** commits the search and shows matching results (searches both keys and values)
+- **Up/Down** move within results
+- **Right** drills into a result but keeps search context
+- **Left** backs up but stops at the search base path
+- **Esc** exits search and restores the prior node
+
+The search query stays visible until you exit search mode.
+
+## Expression Mode
+
+Press `:` to enter expression mode:
+
+- Starts with the current path (prefilled with `_`-rooted CEL path)
+- **Tab / Shift+Tab** — cycle through keys/indices
+- **Up / Down** — cycle through CEL functions valid for the current node type
+- **Right** — accept ghosted completion
+- **Enter** — evaluate the expression and stay in expression mode; errors show in red
+- **Esc** — exit expression mode; non-navigable results fall back to the path you started from
+- While in expression mode, **y** copies the current expression
+
+### Expression examples
+
+```
+_.metadata                        # navigate to metadata
+_.items[0]                        # first item
+_.items.filter(x, x.status == "running")  # filter running items
+_.items.map(x, x.name)           # extract names
+type(_)                           # inspect root type
+```
+
+## Snapshot and Scripted Runs
+
+### Snapshot
+
+Render the TUI layout once and exit — useful for CI or scripted output:
+
+```bash
+kvx data.yaml --snapshot
+```
+
+Honors `--width`, `--height`, and `--theme`.
+
+### Scripted Keys (--press)
+
+Feed a sequence of key presses for reproducible end states:
+
+```bash
+# Search for "api"
+kvx data.yaml --snapshot --press "/api<Enter>"
+
+# Navigate with expression
+kvx data.yaml --snapshot --press ":_.items[0]<Enter>"
+
+# Open help then close
+kvx data.yaml --snapshot --press "?<Esc>"
+
+# Multiple operations: search then filter
+kvx data.yaml --snapshot --press "/test<Enter><Esc>me"
+```
+
+Special keys use angle brackets: `<Enter>`, `<Esc>`, `<Tab>`, `<Space>`, `<BS>` (backspace), `<Left>`, `<Right>`, `<Up>`, `<Down>`, `<Home>`, `<End>`, `<C-c>`, `<C-d>`, `<C-u>`, `<C-Space>`, `<F1>`–`<F12>`.
+
+Include `<F10>` in `--press` to bypass the interactive loop and emit non-interactive output directly (works regardless of `--keymap`).
+
+## Debug
+
+```bash
+kvx data.yaml -i --debug
+```
+
+Buffers recent debug events and prints them on exit. Adjust the buffer size with `--debug-max-events N` (default: 200).
+
+## Next Steps
+
+- [CEL Expressions](../expressions/) — Advanced querying patterns
+- [Configuration & Themes](../configuration/) — Customize themes, keymaps, and schemas

--- a/home/_index.md
+++ b/home/_index.md
@@ -1,0 +1,86 @@
+---
+title: "kvx"
+type: docs
+---
+
+# kvx
+
+**Explore structured data interactively in your terminal.**
+
+kvx is a terminal-based UI for exploring JSON, YAML, TOML, NDJSON, CSV, and JWT data in an interactive, navigable way. It presents data as key-value trees that you can expand, collapse, and inspect directly in the terminal.
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/oakwood-commons/kvx)](https://goreportcard.com/report/github.com/oakwood-commons/kvx)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/oakwood-commons/kvx/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/oakwood-commons/kvx)](https://github.com/oakwood-commons/kvx/releases)
+
+---
+
+## Quick Install
+
+```bash
+brew install oakwood-commons/tap/kvx
+```
+
+Or install from source:
+
+```bash
+go install github.com/oakwood-commons/kvx@latest
+```
+
+Or download a binary from [GitHub Releases](https://github.com/oakwood-commons/kvx/releases).
+
+---
+
+## 30-Second Example
+
+```bash
+# Render a YAML file as a table
+kvx data.yaml
+
+# Explore interactively
+kvx data.yaml -i
+
+# Evaluate a CEL expression
+kvx data.yaml -e '_.items[0].name'
+
+# Output as JSON
+kvx data.yaml -e '_.metadata' -o json
+```
+
+---
+
+## Key Features
+
+- **Multi-format** — Auto-detects JSON, YAML, TOML, NDJSON, CSV, and JWT
+- **Interactive TUI** — Navigate, search, filter, and evaluate expressions in the terminal
+- **CEL Expressions** — Use [Common Expression Language](https://cel.dev/) for dynamic querying and filtering
+- **Multiple Output Formats** — Table, list, tree, Mermaid diagrams, CSV, YAML, JSON
+- **Themes** — Built-in themes (midnight, dark, warm, cool) with full customization
+- **Schema Hints** — JSON Schema-driven column display (headers, widths, alignment)
+- **Embeddable** — Use kvx as a Go library in your own applications
+- **Shell Completion** — Bash, Zsh, Fish, and PowerShell support
+
+---
+
+## Documentation
+
+### Tutorials
+- [Getting Started](docs/tutorials/getting-started/) — Install and run your first exploration
+- [Interactive Mode](docs/tutorials/interactive-mode/) — Navigate, search, and evaluate in the TUI
+- [CEL Expressions](docs/tutorials/expressions/) — Dynamic querying with CEL
+- [Configuration & Themes](docs/tutorials/configuration/) — Customize kvx to your workflow
+
+### Reference
+- [TUI Quick Guide](docs/tui/) — Panels, keybindings, and keyboard reference
+- [Library Usage](docs/library-usage/) — Use kvx as a Go library (pkg/core + pkg/tui)
+- [Embedding the TUI](docs/embedding/) — Embed the interactive viewer in your app
+- [Development](docs/development/) — Build, test, and contribute
+
+---
+
+## Links
+
+- [GitHub Repository](https://github.com/oakwood-commons/kvx)
+- [Releases](https://github.com/oakwood-commons/kvx/releases)
+- [Discussions](https://github.com/oakwood-commons/kvx/discussions)
+- [Contributing](https://github.com/oakwood-commons/kvx/blob/main/CONTRIBUTING.md)

--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -1,0 +1,1 @@
+<!-- Custom body injection for kvx docs -->

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/oakwood-commons/kvx/site
+
+go 1.25.8
+
+require github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,0 +1,2 @@
+github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9 h1:IqP5Z74ab1Y5Clr2VjpP086LYXCAouI181XVelpEyY4=
+github.com/alex-shpak/hugo-book v0.0.0-20260316112600-751bde097bc9/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,0 +1,76 @@
+# Hugo Configuration for kvx
+# Documentation: https://gohugo.io/getting-started/configuration/
+# Note: Hugo is run from this directory (site/) so that its
+# go.mod is isolated from the main project's go.mod. Paths in
+# module mounts are relative to this directory.
+
+baseURL: "https://oakwood-commons.github.io/kvx/"
+locale: "en-us"
+title: "kvx"
+enableRobotsTXT: true
+
+# Output to the root public/ directory (consumed by the GitHub Pages CI step)
+publishDir: "../public"
+
+# Use Hugo Modules for theme (no git submodule needed)
+module:
+  imports:
+    - path: github.com/alex-shpak/hugo-book
+  mounts:
+    - source: ../docs
+      target: content/docs
+    - source: ../home
+      target: content
+    - source: ../assets
+      target: assets
+    - source: ../layouts
+      target: layouts
+
+# Repository information
+params:
+  description: "Terminal-based UI for exploring structured data interactively"
+  github_repo: "https://github.com/oakwood-commons/kvx"
+  github_project_repo: "https://github.com/oakwood-commons/kvx"
+
+  # Book theme specific
+  BookMenuBundle: /menu
+  BookSection: docs
+  BookRepo: "https://github.com/oakwood-commons/kvx"
+  BookEditLink: "https://github.com/oakwood-commons/kvx/edit/main/{{ .Path }}"
+  BookDateFormat: "January 2, 2006"
+  BookSearch: true
+  BookComments: false
+  BookToC: true
+
+# Enable syntax highlighting
+markup:
+  highlight:
+    style: github-dark
+    lineNos: false
+    codeFences: true
+    guessSyntax: true
+  goldmark:
+    renderer:
+      unsafe: false
+
+# Menu structure
+menu:
+  before: []
+  after:
+    - name: "GitHub"
+      url: "https://github.com/oakwood-commons/kvx"
+      weight: 10
+
+# Output formats
+outputs:
+  home:
+    - HTML
+    - RSS
+    - JSON
+
+# Enable JSON for search
+outputFormats:
+  JSON:
+    mediaType: application/json
+    baseName: search
+    isPlainText: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -58,6 +58,10 @@ tasks:
         echo "  task tag VERSION=v1.0.0      # Create a signed tag"
         echo "  task tag-push VERSION=v1.0.0 # Create and push a tag"
         echo
+        echo "Docs:"
+        echo "  task docs:build  # Build Hugo documentation site"
+        echo "  task docs:serve  # Serve docs locally (live reload)"
+        echo
         echo "Variables and Values:"
         echo "  NAME:          {{ .NAME }}"
         echo "  OUTPUT_FILE:   {{ .OUTPUT_FILE }}"
@@ -360,3 +364,25 @@ tasks:
         echo "Tag {{.VERSION}} created and pushing to origin..."
         git push origin "{{.VERSION}}"
         echo "Tag {{.VERSION}} pushed."
+
+  docs:build:
+    desc: Build the Hugo documentation site
+    preconditions:
+      - sh: command -v hugo >/dev/null 2>&1
+        msg: "hugo CLI not found. Install: brew install hugo"
+    cmds:
+      - |
+        cd site
+        hugo --gc --minify
+        echo ""
+        echo "Site built to public/"
+
+  docs:serve:
+    desc: Serve the Hugo documentation site locally with live reload
+    preconditions:
+      - sh: command -v hugo >/dev/null 2>&1
+        msg: "hugo CLI not found. Install: brew install hugo"
+    cmds:
+      - |
+        cd site
+        hugo server


### PR DESCRIPTION
Add a complete documentation site using Hugo with the hugo-book theme, including tutorials, guides, and GitHub Actions deployment workflow.

Site infrastructure:
- Hugo config with hugo-book theme via Hugo Modules
- Isolated site/go.mod to avoid polluting main module
- Content mounting: docs/ and home/ directories
- Custom SCSS and partial stubs for extensibility

New documentation content:
- Landing page with badges, quick install, and feature highlights
- Tutorials section: getting-started, interactive-mode, expressions, configuration
- Added Hugo frontmatter to existing docs for sidebar navigation

Build & deploy:
- GitHub Actions workflow for Pages deployment (Hugo 0.158.0)
- Taskfile tasks: docs:build and docs:serve
- GitHub Pages enabled via gh CLI (workflow source)

Also:
- Documentation badge added to README
- Hugo-specific entries added to .gitignore
