### PR TITLE
feat(ci): add Windows testing and winget publishing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+  fork-test-windows:
+    name: Fork Test (Windows)
+    runs-on: windows-latest
+    needs: [changes]
+    if: |
+      needs.changes.outputs.code == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -84,6 +103,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
           fail_ci_if_error: false
+
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    needs: [changes]
+    if: |
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false)
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
 
   lint:
     name: Lint
@@ -146,7 +183,7 @@ jobs:
   test-gate:
     name: Test (gate)
     runs-on: ubuntu-latest
-    needs: [changes, test, fork-test]
+    needs: [changes, test, test-windows, fork-test, fork-test-windows]
     if: always()
     steps:
       - run: |
@@ -154,7 +191,12 @@ jobs:
             echo "No code changes — skipping tests"
             exit 0
           fi
-          if [[ "${{ needs.test.result }}" == "success" || "${{ needs.fork-test.result }}" == "success" ]]; then
+          # Fork PRs: require both Linux and Windows fork tests
+          if [[ "${{ needs.fork-test.result }}" == "success" && "${{ needs.fork-test-windows.result }}" == "success" ]]; then
+            exit 0
+          fi
+          # Non-fork: require both Linux and Windows tests
+          if [[ "${{ needs.test.result }}" == "success" && "${{ needs.test-windows.result }}" == "success" ]]; then
             exit 0
           fi
           echo "Test job failed or was not successful"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,27 @@ jobs:
       - name: Run linter
         run: task lint
 
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
   release:
     name: Release
-    needs: test
+    needs: [test, test-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,6 +91,15 @@ jobs:
           owner: oakwood-commons
           repositories: homebrew-tap
 
+      - name: Generate winget token
+        id: winget-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ vars.OC_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.OC_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: oakwood-commons
+          repositories: winget-pkgs
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
@@ -82,3 +109,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          WINGET_GITHUB_TOKEN: ${{ steps.winget-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,36 @@ homebrew_casks:
     homepage: "https://github.com/oakwood-commons/kvx"
     description: "Terminal-based UI for exploring structured data interactively"
     license: "Apache-2.0"
+winget:
+  - name: kvx
+    publisher: OakwoodCommons
+    short_description: "Terminal-based UI for exploring structured data interactively"
+    license: "Apache-2.0"
+    publisher_url: "https://github.com/oakwood-commons"
+    publisher_support_url: "https://github.com/oakwood-commons/kvx/issues"
+    package_identifier: "OakwoodCommons.kvx"
+    homepage: "https://github.com/oakwood-commons/kvx"
+    description: "kvx is a terminal-based UI for exploring structured data (JSON, YAML, TOML, CSV, JWT) in an interactive, navigable way."
+    license_url: "https://github.com/oakwood-commons/kvx/blob/main/LICENSE"
+    release_notes_url: "https://github.com/oakwood-commons/kvx/releases/tag/{{ .Tag }}"
+    tags:
+      - cli
+      - terminal
+      - data
+      - json
+      - yaml
+    skip_upload: auto
+    repository:
+      owner: oakwood-commons
+      name: winget-pkgs
+      branch: "kvx-{{ .Version }}"
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 release:
   draft: false
   prerelease: auto

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,8 +23,10 @@ git push origin vX.Y.Z
 
 - Archives for linux, darwin, and windows
 - SHA256 checksums
+- Homebrew cask (updated automatically in `oakwood-commons/homebrew-tap`)
+- Winget manifest (PR opened automatically to `microsoft/winget-pkgs`)
 
 ## Notes
 
 - GoReleaser config is in `.goreleaser.yaml`.
-- CI runs tests before publishing.
+- CI runs tests (including Windows) before publishing.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -15,6 +15,12 @@ This tutorial walks you through installing kvx, loading your first data file, an
 brew install oakwood-commons/tap/kvx
 ```
 
+### Windows (winget)
+
+```bash
+winget install OakwoodCommons.kvx
+```
+
 ### From Source
 
 ```bash

--- a/home/_index.md
+++ b/home/_index.md
@@ -17,11 +17,19 @@ kvx is a terminal-based UI for exploring JSON, YAML, TOML, NDJSON, CSV, and JWT 
 
 ## Quick Install
 
+### macOS / Linux (Homebrew)
+
 ```bash
 brew install oakwood-commons/tap/kvx
 ```
 
-Or install from source:
+### Windows (winget)
+
+```bash
+winget install OakwoodCommons.kvx
+```
+
+### From Source
 
 ```bash
 go install github.com/oakwood-commons/kvx@latest


### PR DESCRIPTION
Add Windows platform testing to CI and release workflows to ensure binaries work correctly before shipping to Windows users.

CI changes:
- Add test-windows job running on windows-latest
- Wire Windows tests into test-gate for required status checks

Release changes:
- Add parallel test-windows job alongside Linux tests
- Release now depends on both Linux and Windows test jobs
- Add winget token generation using existing GitHub App
- Pass WINGET_GITHUB_TOKEN to GoReleaser

GoReleaser changes:
- Add winget publisher configuration for oakwood-commons.kvx
- Cross-repo PR from oakwood-commons/winget-pkgs fork to microsoft/winget-pkgs:master
- Skip winget upload for prereleases (skip_upload: auto)

Documentation:
- Update RELEASES.md with winget publishing details
