### PR TITLE
fix(release): manual winget PR workflow and test timeout increase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,3 +115,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           WINGET_GITHUB_TOKEN: ${{ steps.winget-token.outputs.token }}
+
+      - name: Submit winget PR
+        if: success()
+        env:
+          WINGET_PR_PAT: ${{ secrets.WINGET_PR_PAT }}
+          GH_TOKEN: ${{ secrets.WINGET_PR_PAT }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          BRANCH="kvx-${VERSION}"
+
+          # Skip prerelease tags (goreleaser skips winget for prereleases)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "::notice::Skipping winget PR for prerelease version $VERSION"
+            exit 0
+          fi
+
+          if [ -z "$WINGET_PR_PAT" ]; then
+            echo "::warning::No WINGET_PR_PAT secret found. Winget PR must be submitted manually."
+            echo "::notice::Run locally: task winget-pr"
+            exit 0
+          fi
+
+          echo "Creating winget PR with token..."
+          BODY_FILE="$(mktemp)"
+          cat > "$BODY_FILE" <<EOF
+## Automated winget manifest update
+
+Release: https://github.com/oakwood-commons/kvx/releases/tag/$TAG
+EOF
+
+          if gh pr create \
+            --repo microsoft/winget-pkgs \
+            --head "oakwood-commons:$BRANCH" \
+            --base master \
+            --title "New version: OakwoodCommons.kvx version $VERSION" \
+            --body-file "$BODY_FILE"; then
+            echo "::notice::Winget PR created successfully."
+          else
+            echo "::warning::Failed to create winget PR. It may already exist or there was a transient API issue. Submit manually with: task winget-pr"
+          fi
+          rm -f "$BODY_FILE"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,11 +81,7 @@ winget:
       branch: "kvx-{{ .Version }}"
       token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
       pull_request:
-        enabled: true
-        base:
-          owner: microsoft
-          name: winget-pkgs
-          branch: master
+        enabled: false
 release:
   draft: false
   prerelease: auto

--- a/internal/ui/snapshot_cli_test.go
+++ b/internal/ui/snapshot_cli_test.go
@@ -61,7 +61,7 @@ func runSnapshotCLI(t *testing.T, testFile string, args ...string) string {
 	cmdArgs = append(cmdArgs, "run", ".", relTestFile, "--snapshot")
 	cmdArgs = append(cmdArgs, args...)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "go", cmdArgs...)
 	cmd.Dir = projectRoot

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -351,6 +351,32 @@ tasks:
         echo "To build the release:"
         echo "  task release"
 
+  winget-pr:
+    desc: Open a winget PR to microsoft/winget-pkgs for the latest release
+    preconditions:
+      - sh: command -v gh >/dev/null 2>&1
+        msg: "gh CLI is not installed. Install it from https://cli.github.com/"
+      - sh: gh auth status >/dev/null 2>&1
+        msg: "gh CLI is not authenticated. Run: gh auth login"
+    cmds:
+      - |
+        VERSION="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)"
+        if [ -z "$VERSION" ]; then
+          echo "Error: no stable release tag found"
+          exit 1
+        fi
+        BRANCH="kvx-${VERSION#v}"
+        echo "Submitting winget PR for $VERSION (branch: $BRANCH)..."
+        BODY_FILE="$(mktemp)"
+        printf '## Automated winget manifest update\n\nRelease: https://github.com/oakwood-commons/kvx/releases/tag/%s\n' "$VERSION" > "$BODY_FILE"
+        gh pr create \
+          --repo microsoft/winget-pkgs \
+          --head "oakwood-commons:$BRANCH" \
+          --base master \
+          --title "New version: OakwoodCommons.kvx version ${VERSION#v}" \
+          --body-file "$BODY_FILE"
+        rm -f "$BODY_FILE"
+
   tag-push:
     desc: "Create and push a git tag (usage: task tag-push VERSION=v1.0.0)"
     vars:


### PR DESCRIPTION
- Disable automatic winget PR creation in .goreleaser.yaml (cross-fork PRs to microsoft/winget-pkgs require user auth, not GitHub App tokens)
- Add conditional "Submit winget PR" step in release.yml that uses WINGET_PR_PAT secret if available, otherwise prints instructions
- Add `task winget-pr` for local PR submission using gh CLI with auto-detection of latest version from git tags
- Increase snapshot test timeout from 5s to 30s to handle cold cache builds on CI

The branch push to oakwood-commons/winget-pkgs still uses the app token. If WINGET_PR_PAT (classic PAT with public_repo scope) is added later, releases become fully automated with no code changes.

