### PR TITLE
fix: prevent infinite recursion on `kvx -i --help` while preserving T…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2603,11 +2603,20 @@ var rootCmd = &cobra.Command{
 			rootData, _, err := loadInputData(args, expression, debugLog, dc, *logger.FromContext(rootCtx))
 			if err != nil {
 				if errors.Is(err, errShowHelp) {
-					_ = cmd.Help()
-					return
+					// When --help was explicitly requested with -i, use empty data so
+					// the TUI can start with the F1 help overlay instead of recursing
+					// back into cmd.Help().
+					helpFlag := cmd.Flags().Lookup("help")
+					if helpFlag != nil && helpFlag.Changed {
+						rootData = map[string]any{}
+					} else {
+						_ = cmd.Help()
+						return
+					}
+				} else {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(2)
 				}
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(2)
 			}
 			// Eager auto-decode: recursively decode all serialized scalars before
 			// expression evaluation so that CEL can see the decoded structures.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -991,6 +991,35 @@ func TestSnapshotStartKeyF1ShowsHelp(t *testing.T) {
 	// Help overlay may occupy the main panel; no strict header requirement here.
 }
 
+// TestInteractiveHelpNoInputShowsTUIHelp is a regression test for the fix to
+// the infinite recursion panic when running `kvx -i --help` with no input data.
+// It verifies that the TUI starts with the F1 help overlay using empty data
+// instead of recursing into cmd.Help().
+func TestInteractiveHelpNoInputShowsTUIHelp(t *testing.T) {
+	out := runCLI(t, []string{
+		"kvx",
+		"-i",
+		"--help",
+		"--snapshot",
+		"--width", "80",
+		"--height", "24",
+		"--no-color",
+	})
+
+	// Should show TUI help overlay, not text help
+	if !strings.Contains(strings.ToLower(out), "navigation") {
+		t.Fatalf("expected TUI help overlay with Navigation section, got:\n%s", out)
+	}
+	// Help overlay typically contains keybinding hints
+	if !strings.Contains(out, "j/k") || !strings.Contains(out, "h/l") {
+		t.Fatalf("expected keybinding hints in TUI help overlay, got:\n%s", out)
+	}
+	// Should NOT contain text help markers (Usage:, Examples:)
+	if strings.Contains(out, "Usage:") && strings.Contains(out, "Examples:") {
+		t.Fatalf("expected TUI help overlay, not text help output, got:\n%s", out)
+	}
+}
+
 // ansiStripRe strips ANSI escape sequences for width measurements.
 var ansiStripRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\[m`)
 


### PR DESCRIPTION
…UI help

When running `kvx -i --help` without a data file, the application would panic due to infinite recursion:
1. Custom help func detects `-i` flag → calls `cmd.Run()`
2. `cmd.Run()` with no data → `loadInputData` returns `errShowHelp`
3. `errShowHelp` handler calls `cmd.Help()` → back to step 1

The fix breaks the recursion in the `errShowHelp` handler by checking if `--help` was explicitly requested. When true, it provides empty data (`map[string]any{}`) so the TUI starts normally with the F1 help overlay seeded. When `--help` wasn't requested (e.g., `kvx -i` with no data), it safely falls through to `cmd.Help()` since `helpRequested` is false in the custom help func.

Tested scenarios:
- `kvx --help` → text help, exit 0
- `kvx -i --help` → TUI with F1 help overlay (fixed)
- `kvx -i` (no data) → text help, exit 0 (no panic)
- `kvx file.yaml -i --help` → TUI with F1 help overlay