### PR TITLE
feat(cel): add --where flag for per-item list filtering

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,181 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark Comparison
+    # Only run on PRs from the same repo (not forks — no write access)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      # count=5 is enough for benchstat statistical significance while keeping runtime reasonable
+      BENCH_COUNT: 5
+      BENCH_TIME: 1s
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260312031701-16a31bc5fbd0
+
+      # Only benchmark packages that were actually changed in this PR
+      # and contain benchmark tests — avoids running the full suite on every PR.
+      - name: Find changed benchmark packages
+        id: find-bench
+        run: |
+          # Get Go packages that have changed files in this PR
+          CHANGED_PKGS=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD -- '*.go' \
+            | xargs -I{} dirname {} \
+            | sort -u \
+            | sed 's|^\./|./|; s|^|./|; s|^\./\./|./|' \
+            || true)
+
+          if [ -z "$CHANGED_PKGS" ]; then
+            echo "No Go packages changed, skipping."
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # From those changed packages, keep only the ones that have benchmark tests
+          BENCH_PKGS=""
+          for pkg in $CHANGED_PKGS; do
+            if grep -rl --include='*_test.go' 'func Benchmark' "$pkg" >/dev/null 2>&1; then
+              BENCH_PKGS="$BENCH_PKGS $pkg"
+            fi
+          done
+          BENCH_PKGS=$(echo "$BENCH_PKGS" | xargs)
+
+          if [ -z "$BENCH_PKGS" ]; then
+            echo "Changed packages have no benchmarks, skipping."
+            echo "packages=" >> "$GITHUB_OUTPUT"
+          else
+            echo "packages=$BENCH_PKGS" >> "$GITHUB_OUTPUT"
+            echo "Found changed benchmark packages: $BENCH_PKGS"
+          fi
+
+      - name: Run benchmarks on PR branch
+        if: steps.find-bench.outputs.packages != ''
+        run: |
+          go test -run='^$' -bench='.' -benchmem \
+            -benchtime="${BENCH_TIME}" -count="${BENCH_COUNT}" \
+            -timeout=20m \
+            -short \
+            ${{ steps.find-bench.outputs.packages }} | tee pr-bench.txt
+
+      - name: Checkout base branch
+        if: steps.find-bench.outputs.packages != ''
+        run: git checkout "${{ github.event.pull_request.base.sha }}"
+
+      - name: Run benchmarks on base branch
+        if: steps.find-bench.outputs.packages != ''
+        run: |
+          go test -run='^$' -bench='.' -benchmem \
+            -benchtime="${BENCH_TIME}" -count="${BENCH_COUNT}" \
+            -timeout=20m \
+            -short \
+            ${{ steps.find-bench.outputs.packages }} | tee base-bench.txt
+
+      - name: Compare benchmarks
+        if: steps.find-bench.outputs.packages != ''
+        id: benchstat
+        run: |
+          set +e
+          RESULT=$(benchstat base-bench.txt pr-bench.txt 2>&1)
+          EMPTY=false
+          if [ -z "$RESULT" ] || echo "$RESULT" | grep -q 'no data'; then
+            EMPTY=true
+          fi
+          echo "empty=$EMPTY" >> "$GITHUB_OUTPUT"
+          # Use a file to pass the result to avoid env-var escaping issues
+          echo "$RESULT" > benchstat-result.txt
+          set -e
+
+      - name: Post benchmark comparison
+        if: steps.find-bench.outputs.packages != '' && steps.benchstat.outputs.empty != 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- benchmark-comparison -->';
+            let result = 'No results available';
+            try {
+              result = fs.readFileSync('benchstat-result.txt', 'utf8').trim();
+            } catch (e) {
+              console.log('Could not read benchstat-result.txt:', e.message);
+            }
+            const count = process.env.BENCH_COUNT || '5';
+            const benchTime = process.env.BENCH_TIME || '1s';
+            const body = [
+              marker,
+              '## Benchmark Comparison',
+              '',
+              '<details>',
+              '<summary>Click to expand benchmark results</summary>',
+              '',
+              '```',
+              result,
+              '```',
+              '',
+              '</details>',
+              '',
+              '> **How to read**: `~` means no significant change, `+` means regression, `-` means improvement. `p`-value >= 0.05 means the difference is not statistically significant.',
+              '>',
+              `> Benchmarks ran with \`-count=${count}\` and \`-benchtime=${benchTime}\`.`,
+            ].join('\n');
+
+            const prNumber = context.payload.pull_request?.number;
+            if (!prNumber) {
+              console.log('No PR number found, skipping comment.');
+              return;
+            }
+
+            // Find and update existing comment, or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+        env:
+          BENCH_COUNT: ${{ env.BENCH_COUNT }}
+          BENCH_TIME: ${{ env.BENCH_TIME }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,6 +187,7 @@ var (
 	output          string // for rootCmd (default: table)
 	configOutput    string // for configCmd (default: yaml)
 	expression      string
+	whereExpr       string
 	searchTerm      string
 	themeName       string
 	configFile      string
@@ -1886,6 +1887,49 @@ func validateLimitingFlags() error {
 	return cfg.Validate()
 }
 
+// applyWhereFilter applies the --where per-item boolean filter if set.
+// It prints an error and exits on failure.
+func applyWhereFilter(data interface{}, debugLog bool, dc *debugCollector) interface{} {
+	if whereExpr == "" {
+		return data
+	}
+	if debugLog {
+		dc.Printf("DBG: Applying --where filter: %s\n", whereExpr)
+	}
+	engine, err := core.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
+		os.Exit(1)
+	}
+	filtered, err := engine.EvaluateWhere(whereExpr, data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "where filter error: %v\n", err)
+		if hint := buildWhereHint(err, whereExpr); hint != "" {
+			fmt.Fprintln(os.Stderr, hint)
+		}
+		os.Exit(2)
+	}
+	if debugLog {
+		dc.Printf("DBG: --where filtered %d items\n", len(filtered))
+	}
+	// EvaluateWhere already returns a fresh []interface{}.
+	return filtered
+}
+
+// buildWhereHint returns a helpful suggestion when a --where expression fails.
+// Currently detects "no such key" errors and suggests using has() to guard
+// against items that lack the referenced field.
+func buildWhereHint(err error, expr string) string {
+	msg := err.Error()
+	const prefix = "no such key: "
+	idx := strings.Index(msg, prefix)
+	if idx < 0 {
+		return ""
+	}
+	key := msg[idx+len(prefix):]
+	return fmt.Sprintf("Hint: not all items have key %q. Try: has(_.%s) && %s", key, key, expr)
+}
+
 // applyLimiting applies the record-limiting configuration to data.
 func applyLimiting(data interface{}) interface{} {
 	cfg := limiter.Config{
@@ -2482,7 +2526,7 @@ var rootCmd = &cobra.Command{
 	Use:     "kvx [file]",
 	Short:   getCLIShortHelp(),
 	Long:    getCLILongHelp(),
-	Example: "\n  kvx tests/sample.yaml\n  kvx tests/sample.yaml -e '_.items[0].name'\n  kvx tests/sample.yaml -e 'type(_)'\n  kvx tests/sample.yaml -e '_.metadata[\"bad-key\"]'\n  type tests/sample.yaml | kvx -e '_.items.filter(x, x.available)'\n",
+	Example: "\n  kvx tests/sample.yaml\n  kvx tests/sample.yaml -e '_.items[0].name'\n  kvx tests/sample.yaml -e 'type(_)'\n  kvx tests/sample.yaml -e '_.metadata[\"bad-key\"]'\n  kvx tests/sample.yaml -w '_.available == true'\n  kvx tests/sample.yaml -w '_.type == \"oci\"' -e '_.map(x, x.name)'\n  type tests/sample.yaml | kvx -e '_.items.filter(x, x.available)'\n",
 	Args:    cobra.MaximumNArgs(1),
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		// Initialize structured logger with JSON output
@@ -2623,6 +2667,9 @@ var rootCmd = &cobra.Command{
 			if autoDecode == "eager" {
 				rootData = loader.RecursiveDecode(rootData)
 			}
+
+			// Apply --where per-item filter before expression
+			rootData = applyWhereFilter(rootData, debugLog, dc)
 
 			// Evaluate expression for snapshot parity with CLI limiting
 			snapshotNode := rootData
@@ -3021,6 +3068,9 @@ var rootCmd = &cobra.Command{
 			root = loader.RecursiveDecode(root)
 		}
 
+		// Apply --where per-item filter before expression
+		root = applyWhereFilter(root, debugLog, dc)
+
 		// All interactive and snapshot flows are handled earlier; reaching here should
 		// always mean non-interactive CLI output.
 		if interactive || renderSnapshot {
@@ -3161,6 +3211,7 @@ func init() { //nolint:gochecknoinits
 	rootCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "start interactive TUI")
 	rootCmd.Flags().StringVarP(&output, "output", "o", "auto", "output format: auto|table|list|tree|mermaid|yaml|json|toml|csv|raw")
 	rootCmd.Flags().StringVarP(&expression, "expression", "e", "", "CEL expression using '_' as root. Examples: '_.items[0].name', 'type(_)'. For special keys use bracket notation: '_.metadata[\"bad-key\"]'.")
+	rootCmd.Flags().StringVarP(&whereExpr, "where", "w", "", "Per-item CEL boolean filter for list data. '_' refers to the current item. Example: '_.type == \"oci\"'")
 	rootCmd.Flags().StringVar(&searchTerm, "search", "", "Search keys and values (case-insensitive) and display matches")
 	// --sort requires a value; default comes from config (or none)
 	rootCmd.Flags().StringVar(&sortOrder, "sort", "", "Sort map keys: ascending|asc|descending|desc|none (default from config or none)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1889,17 +1889,12 @@ func validateLimitingFlags() error {
 
 // applyWhereFilter applies the --where per-item boolean filter if set.
 // It prints an error and exits on failure.
-func applyWhereFilter(data interface{}, debugLog bool, dc *debugCollector) interface{} {
+func applyWhereFilter(engine *core.Engine, data interface{}, debugLog bool, dc *debugCollector) interface{} {
 	if whereExpr == "" {
 		return data
 	}
 	if debugLog {
 		dc.Printf("DBG: Applying --where filter: %s\n", whereExpr)
-	}
-	engine, err := core.New()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
-		os.Exit(1)
 	}
 	filtered, err := engine.EvaluateWhere(whereExpr, data)
 	if err != nil {
@@ -1916,18 +1911,34 @@ func applyWhereFilter(data interface{}, debugLog bool, dc *debugCollector) inter
 	return filtered
 }
 
+var (
+	whereMissingKeyPattern = regexp.MustCompile(`no such key:\s*(?:"([^"]+)"|(\S+))`)
+	whereIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
 // buildWhereHint returns a helpful suggestion when a --where expression fails.
 // Currently detects "no such key" errors and suggests using has() to guard
 // against items that lack the referenced field.
 func buildWhereHint(err error, expr string) string {
-	msg := err.Error()
-	const prefix = "no such key: "
-	idx := strings.Index(msg, prefix)
-	if idx < 0 {
+	matches := whereMissingKeyPattern.FindStringSubmatch(err.Error())
+	if len(matches) == 0 {
 		return ""
 	}
-	key := msg[idx+len(prefix):]
-	return fmt.Sprintf("Hint: not all items have key %q. Try: has(_.%s) && %s", key, key, expr)
+
+	key := matches[1]
+	if key == "" {
+		key = matches[2]
+	}
+	if key == "" {
+		return ""
+	}
+
+	accessor := "_." + key
+	if !whereIdentifierPattern.MatchString(key) {
+		accessor = "_[" + strconv.Quote(key) + "]"
+	}
+
+	return fmt.Sprintf("Hint: not all items have key %q. Try: has(%s) && %s", key, accessor, expr)
 }
 
 // applyLimiting applies the record-limiting configuration to data.
@@ -2668,19 +2679,21 @@ var rootCmd = &cobra.Command{
 				rootData = loader.RecursiveDecode(rootData)
 			}
 
-			// Apply --where per-item filter before expression
-			rootData = applyWhereFilter(rootData, debugLog, dc)
+			// Apply --where per-item filter and evaluate expression.
+			// Create one engine for both operations to avoid redundant initialization.
+			engine, err := core.New()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
+				os.Exit(1)
+			}
+
+			rootData = applyWhereFilter(engine, rootData, debugLog, dc)
 
 			// Evaluate expression for snapshot parity with CLI limiting
 			snapshotNode := rootData
 			if expression != "" {
 				if debug {
 					dc.Printf("DBG: Evaluating expression for snapshot: %s\n", expression)
-				}
-				engine, err := core.New()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
-					os.Exit(1)
 				}
 				n, err := engine.Evaluate(expression, rootData)
 				if err != nil {
@@ -3068,8 +3081,15 @@ var rootCmd = &cobra.Command{
 			root = loader.RecursiveDecode(root)
 		}
 
-		// Apply --where per-item filter before expression
-		root = applyWhereFilter(root, debugLog, dc)
+		// Apply --where per-item filter and evaluate expression.
+		// Create one engine for both operations to avoid redundant initialization.
+		engine, err := core.New()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
+			os.Exit(1)
+		}
+
+		root = applyWhereFilter(engine, root, debugLog, dc)
 
 		// All interactive and snapshot flows are handled earlier; reaching here should
 		// always mean non-interactive CLI output.
@@ -3086,11 +3106,6 @@ var rootCmd = &cobra.Command{
 				dc.Printf("DBG: Evaluating expression: %s\n", expression)
 			}
 			// Strict CLI mode: evaluate explore as CEL; require explicit '_' or valid CEL
-			engine, err := core.New()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to init evaluator: %v\n", err)
-				os.Exit(1)
-			}
 			n, err := engine.Evaluate(expression, root)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "explore expression error: %v\n", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -126,6 +126,7 @@ func resetRootCmdState() {
 	interactive = false
 	output = "auto"
 	expression = ""
+	whereExpr = ""
 	searchTerm = ""
 	debug = false
 	noColor = false
@@ -752,6 +753,74 @@ func TestCLI_LimitingTailIgnoresOffsetJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &arr))
 	require.Len(t, arr, 1)
 	require.Equal(t, "matcha", arr[0]["name"])
+}
+
+func TestCLI_WhereFiltersNDJSON(t *testing.T) {
+	out := runCLI(t, []string{"kvx", filepath.Join("..", "tests", "sample.ndjson"), "-o", "json", "-w", `_.level == "ERROR"`})
+	var arr []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "ERROR", arr[0]["level"])
+	assert.Equal(t, "payment-service", arr[0]["service"])
+}
+
+func TestCLI_WhereWithExpressionComposition(t *testing.T) {
+	// --where filters first, then -e transforms
+	out := runCLI(t, []string{"kvx", filepath.Join("..", "tests", "sample.ndjson"), "-o", "json", "-w", `_.level == "INFO"`, "-e", `_.map(x, x.service)`})
+	var arr []interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &arr))
+	require.Len(t, arr, 3)
+	for _, v := range arr {
+		assert.Contains(t, []string{"api-gateway", "database"}, v)
+	}
+}
+
+func TestCLI_WhereWithLimit(t *testing.T) {
+	out := runCLI(t, []string{"kvx", filepath.Join("..", "tests", "sample.ndjson"), "-o", "json", "-w", `_.level == "INFO"`, "--limit", "1"})
+	var arr []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "INFO", arr[0]["level"])
+}
+
+func TestCLI_WhereEmptyResult(t *testing.T) {
+	out := runCLI(t, []string{"kvx", filepath.Join("..", "tests", "sample.ndjson"), "-o", "json", "-w", `_.level == "NONEXISTENT"`})
+	var arr []interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &arr))
+	assert.Empty(t, arr)
+}
+
+func TestBuildWhereHint(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		expr    string
+		want    string
+		wantNil bool
+	}{
+		{
+			name: "no such key suggests has()",
+			err:  fmt.Errorf("where filter eval error: no such key: user_id"),
+			expr: "_.user_id > 200",
+			want: `Hint: not all items have key "user_id". Try: has(_.user_id) && _.user_id > 200`,
+		},
+		{
+			name:    "unrelated error returns empty",
+			err:     fmt.Errorf("some other error"),
+			expr:    "_.x == 1",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := buildWhereHint(tt.err, tt.expr)
+			if tt.wantNil {
+				assert.Empty(t, hint)
+			} else {
+				assert.Equal(t, tt.want, hint)
+			}
+		})
+	}
 }
 
 func TestSuggestion_SpecialCharKey(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -805,6 +805,18 @@ func TestBuildWhereHint(t *testing.T) {
 			want: `Hint: not all items have key "user_id". Try: has(_.user_id) && _.user_id > 200`,
 		},
 		{
+			name: "special char key uses bracket notation",
+			err:  fmt.Errorf(`no such key: "bad-key"`),
+			expr: `_["bad-key"] == "x"`,
+			want: `Hint: not all items have key "bad-key". Try: has(_["bad-key"]) && _["bad-key"] == "x"`,
+		},
+		{
+			name: "key with dots uses bracket notation",
+			err:  fmt.Errorf("no such key: my.field"),
+			expr: `_["my.field"] == 1`,
+			want: `Hint: not all items have key "my.field". Try: has(_["my.field"]) && _["my.field"] == 1`,
+		},
+		{
 			name:    "unrelated error returns empty",
 			err:     fmt.Errorf("some other error"),
 			expr:    "_.x == 1",

--- a/internal/cel/evaluator.go
+++ b/internal/cel/evaluator.go
@@ -93,6 +93,63 @@ func (e *Evaluator) Evaluate(expr string, data interface{}) (interface{}, error)
 	return EvaluateExpressionWithEnv(e.env, expr, data)
 }
 
+// EvaluateWhere filters a list by applying a CEL boolean expression to each item.
+// The expression receives each item as '_'. Returns the filtered list.
+// Returns an error if data is not a list or the expression does not return bool.
+func (e *Evaluator) EvaluateWhere(expr string, data interface{}) ([]interface{}, error) {
+	items, ok := toSlice(data)
+	if !ok {
+		return nil, fmt.Errorf("EvaluateWhere requires list data; got %T", data)
+	}
+
+	// Compile the program once and reuse for each item.
+	ast, issues := e.env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("where filter compilation error: %w", issues.Err())
+	}
+
+	prg, err := e.env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("where filter program error: %w", err)
+	}
+
+	result := make([]interface{}, 0, len(items))
+
+	for _, item := range items {
+		out, _, err := prg.Eval(map[string]interface{}{"_": item})
+		if err != nil {
+			return nil, fmt.Errorf("where filter eval error: %w", err)
+		}
+
+		b, ok := out.Value().(bool)
+		if !ok {
+			return nil, fmt.Errorf("where filter expression must return a boolean, got %s", out.Type().TypeName())
+		}
+
+		if b {
+			result = append(result, item)
+		}
+	}
+
+	return result, nil
+}
+
+// toSlice converts data to []interface{} if it is a slice type.
+func toSlice(data interface{}) ([]interface{}, bool) {
+	switch v := data.(type) {
+	case []interface{}:
+		return v, true
+	case []map[string]interface{}:
+		s := make([]interface{}, len(v))
+		for i, item := range v {
+			s[i] = item
+		}
+		return s, true
+	default:
+		return nil, false
+	}
+}
+
 // ToGo converts CEL types to Go native types recursively.
 // Handles both CEL primitive types and collection types (List, Map).
 func ToGo(val ref.Val) interface{} {

--- a/internal/cel/evaluator.go
+++ b/internal/cel/evaluator.go
@@ -108,15 +108,23 @@ func (e *Evaluator) EvaluateWhere(expr string, data interface{}) ([]interface{},
 		return nil, fmt.Errorf("where filter compilation error: %w", issues.Err())
 	}
 
+	// Reject expressions whose compile-time output type is known and non-boolean.
+	if ot := ast.OutputType(); ot != nil && ot.String() != "bool" && ot.String() != "dyn" {
+		return nil, fmt.Errorf("where filter expression must return a boolean, got %s", ot)
+	}
+
 	prg, err := e.env.Program(ast)
 	if err != nil {
 		return nil, fmt.Errorf("where filter program error: %w", err)
 	}
 
 	result := make([]interface{}, 0, len(items))
+	activation := map[string]interface{}{"_": nil}
 
 	for _, item := range items {
-		out, _, err := prg.Eval(map[string]interface{}{"_": item})
+		activation["_"] = item
+
+		out, _, err := prg.Eval(activation)
 		if err != nil {
 			return nil, fmt.Errorf("where filter eval error: %w", err)
 		}

--- a/internal/cel/evaluator_where_test.go
+++ b/internal/cel/evaluator_where_test.go
@@ -1,0 +1,142 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateWhere(t *testing.T) {
+	eval, err := NewEvaluator()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		data     interface{}
+		expected []interface{}
+		wantErr  string
+	}{
+		{
+			name: "filter maps by field",
+			expr: `_.type == "oci"`,
+			data: []interface{}{
+				map[string]interface{}{"name": "a", "type": "oci"},
+				map[string]interface{}{"name": "b", "type": "helm"},
+				map[string]interface{}{"name": "c", "type": "oci"},
+			},
+			expected: []interface{}{
+				map[string]interface{}{"name": "a", "type": "oci"},
+				map[string]interface{}{"name": "c", "type": "oci"},
+			},
+		},
+		{
+			name:     "filter scalars",
+			expr:     `_ > 3`,
+			data:     []interface{}{int64(1), int64(2), int64(5), int64(4)},
+			expected: []interface{}{int64(5), int64(4)},
+		},
+		{
+			name: "no matches returns empty",
+			expr: `_.active == true`,
+			data: []interface{}{
+				map[string]interface{}{"active": false},
+			},
+			expected: []interface{}{},
+		},
+		{
+			name: "all match",
+			expr: `_.ok == true`,
+			data: []interface{}{
+				map[string]interface{}{"ok": true},
+				map[string]interface{}{"ok": true},
+			},
+			expected: []interface{}{
+				map[string]interface{}{"ok": true},
+				map[string]interface{}{"ok": true},
+			},
+		},
+		{
+			name:     "empty list",
+			expr:     `_ > 0`,
+			data:     []interface{}{},
+			expected: []interface{}{},
+		},
+		{
+			name: "nested field access",
+			expr: `_.metadata.env == "prod"`,
+			data: []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"env": "prod"}},
+				map[string]interface{}{"metadata": map[string]interface{}{"env": "dev"}},
+			},
+			expected: []interface{}{
+				map[string]interface{}{"metadata": map[string]interface{}{"env": "prod"}},
+			},
+		},
+		{
+			name:    "non-list input errors",
+			expr:    `_.name == "x"`,
+			data:    map[string]interface{}{"name": "x"},
+			wantErr: "EvaluateWhere requires list data",
+		},
+		{
+			name:    "non-boolean expression errors",
+			expr:    `_.name`,
+			data:    []interface{}{map[string]interface{}{"name": "x"}},
+			wantErr: "where filter expression must return a boolean",
+		},
+		{
+			name:    "invalid CEL syntax errors",
+			expr:    `_.name ==`,
+			data:    []interface{}{map[string]interface{}{"name": "x"}},
+			wantErr: "where filter compilation error",
+		},
+		{
+			name: "typed map slice input",
+			expr: `_.count > 1`,
+			data: []map[string]interface{}{
+				{"count": int64(2)},
+				{"count": int64(0)},
+			},
+			expected: []interface{}{
+				map[string]interface{}{"count": int64(2)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := eval.EvaluateWhere(tt.expr, tt.data)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func BenchmarkEvaluateWhere(b *testing.B) {
+	eval, err := NewEvaluator()
+	require.NoError(b, err)
+
+	items := make([]interface{}, 1000)
+	for i := range items {
+		items[i] = map[string]interface{}{
+			"index":  int64(i),
+			"active": i%2 == 0,
+		}
+	}
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, err := eval.EvaluateWhere(`_.active == true`, items)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/cel/evaluator_where_test.go
+++ b/internal/cel/evaluator_where_test.go
@@ -81,10 +81,22 @@ func TestEvaluateWhere(t *testing.T) {
 			wantErr: "EvaluateWhere requires list data",
 		},
 		{
-			name:    "non-boolean expression errors",
+			name:    "non-boolean expression errors at runtime",
 			expr:    `_.name`,
 			data:    []interface{}{map[string]interface{}{"name": "x"}},
 			wantErr: "where filter expression must return a boolean",
+		},
+		{
+			name:    "non-boolean expression rejected at compile time",
+			expr:    `size(_)`,
+			data:    []interface{}{map[string]interface{}{"name": "x"}},
+			wantErr: "where filter expression must return a boolean, got int",
+		},
+		{
+			name:    "non-boolean expression on empty list rejected",
+			expr:    `_.name + "x"`,
+			data:    []interface{}{},
+			wantErr: "where filter expression must return a boolean, got string",
 		},
 		{
 			name:    "invalid CEL syntax errors",

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -13,6 +13,11 @@ import (
 // Evaluator evaluates expressions against a root node.
 type Evaluator interface {
 	Evaluate(expr string, root interface{}) (interface{}, error)
+}
+
+// WhereEvaluator optionally evaluates per-item boolean filters against list data.
+// Evaluators that support --where filtering should implement this interface.
+type WhereEvaluator interface {
 	EvaluateWhere(expr string, root interface{}) ([]interface{}, error)
 }
 
@@ -143,11 +148,16 @@ func (e *Engine) Evaluate(expr string, root interface{}) (interface{}, error) {
 }
 
 // EvaluateWhere filters list data by applying a per-item boolean expression.
+// The evaluator must implement WhereEvaluator; otherwise an error is returned.
 func (e *Engine) EvaluateWhere(expr string, root interface{}) ([]interface{}, error) {
 	if e == nil || e.Evaluator == nil {
 		return nil, fmt.Errorf("evaluator is not configured")
 	}
-	return e.Evaluator.EvaluateWhere(expr, root)
+	weval, ok := e.Evaluator.(WhereEvaluator)
+	if !ok {
+		return nil, fmt.Errorf("evaluator does not support where filtering")
+	}
+	return weval.EvaluateWhere(expr, root)
 }
 
 // NodeAtPath navigates a path into the root using navigator rules.

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -13,6 +13,7 @@ import (
 // Evaluator evaluates expressions against a root node.
 type Evaluator interface {
 	Evaluate(expr string, root interface{}) (interface{}, error)
+	EvaluateWhere(expr string, root interface{}) ([]interface{}, error)
 }
 
 // Navigator defines navigation and row conversion behavior.
@@ -139,6 +140,14 @@ func (e *Engine) Evaluate(expr string, root interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("evaluator is not configured")
 	}
 	return e.Evaluator.Evaluate(expr, root)
+}
+
+// EvaluateWhere filters list data by applying a per-item boolean expression.
+func (e *Engine) EvaluateWhere(expr string, root interface{}) ([]interface{}, error) {
+	if e == nil || e.Evaluator == nil {
+		return nil, fmt.Errorf("evaluator is not configured")
+	}
+	return e.Evaluator.EvaluateWhere(expr, root)
 }
 
 // NodeAtPath navigates a path into the root using navigator rules.

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -49,6 +49,7 @@ tasks:
         echo "  task lint      # Runs golangci-lint"
         echo "  task test      # Runs unit tests"
         echo "  task coverage  # Runs tests with coverage report"
+        echo "  task bench     # Runs Go benchmarks"
         echo "  task ci        # mod + lint + test + coverage"
         echo "  task codeql    # Run CodeQL security analysis locally"
         echo
@@ -289,6 +290,11 @@ tasks:
         go tool cover -func=coverage.out | awk '
           /^total:/ { printf "\n%-60s %s\n\n", "TOTAL COVERAGE:", $3 }
         '
+
+  bench:
+    desc: Run all Go benchmarks
+    cmds:
+      - go test -run='^\$' -bench='.' -benchmem -count=5 -timeout=20m ./...
 
   go-test:
     desc: Alias for 'test'


### PR DESCRIPTION
Add -w/--where CLI flag that applies a CEL boolean expression to each item in a list, complementing the existing -e/--expression flag which operates on the whole data structure. Composition: --where filters first, then -e transforms the result.

- Add EvaluateWhere() to CEL evaluator with compile-once/eval-per-item
- Add EvaluateWhere to core.Evaluator interface and Engine method
- Register -w/--where flag and wire into snapshot, F10, and CLI paths
- Add toSlice() helper for []interface{} and []map[string]interface{}
- Add 10 table-driven unit tests and a 1K-item benchmark
- Update command examples with --where usage