### PR TITLE
feat(formatter): render multi-line values in key-value table view

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1342,6 +1342,14 @@ func tableFormatOptionsFromConfig(cfg ui.ThemeConfigFile) formatter.TableFormatO
 		opts.HiddenColumns = cfg.Formatting.Table.HiddenColumns
 	}
 
+	// Apply multi-line value cap from config, or reset to the formatter
+	// default so state from an earlier call cannot leak into this run.
+	if cfg.Formatting.Table.MaxValueLines != nil {
+		formatter.SetMaxValueLines(*cfg.Formatting.Table.MaxValueLines)
+	} else {
+		formatter.SetMaxValueLines(formatter.DefaultMaxValueLines())
+	}
+
 	// Load JSON Schema for column display hints.
 	// Priority: CLI --schema flag > config schema_file > config inline schema.
 	var schemaHints map[string]tui.ColumnHint
@@ -2940,6 +2948,7 @@ var rootCmd = &cobra.Command{
 			}
 			cfg = cfgFile
 			keyColWidthPtr = cfgFile.Display.KeyColWidth
+			valueColWidthPtr = cfgFile.Display.ValueColWidth
 		} else {
 			// No config file - load default config and initialize themes
 			cfgFile, err := loadConfigState("", themeName, themeFlagSet, true, true, false)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2272,3 +2272,140 @@ func TestCLI_EmbeddedJSON(t *testing.T) {
 	out := runCLI(t, []string{"kvx", filepath.Join("..", "tests", "embedded_json.json"), "--no-color"})
 	assert.NotEmpty(t, out)
 }
+
+func TestCLI_MultilineValueRendersMultipleRows(t *testing.T) {
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-o", "table",
+	})
+	// "description" value should span 3 rows: first with key, two continuation lines
+	assert.Contains(t, out, "description")
+	assert.Contains(t, out, "line one")
+	assert.Contains(t, out, "line two")
+	assert.Contains(t, out, "line three")
+
+	// Continuation lines should have blank key column (indented under value)
+	lines := strings.Split(out, "\n")
+	var descIdx int
+	for i, l := range lines {
+		if strings.Contains(l, "description") && strings.Contains(l, "line one") {
+			descIdx = i
+			break
+		}
+	}
+	require.Greater(t, descIdx, 0, "should find 'description  line one' row")
+	// Next line should be a continuation (no key, just indented value)
+	require.Contains(t, lines[descIdx+1], "line two")
+	assert.NotContains(t, lines[descIdx+1], "description", "continuation line should not repeat key")
+}
+
+func TestCLI_MultilineTruncatesAtMaxValueLines(t *testing.T) {
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-o", "table",
+	})
+	// "config" has 12 lines; default maxValueLines=10, so it should truncate
+	assert.Contains(t, out, "config")
+	// First 10 lines (a through j) should appear
+	for _, ch := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+		assert.Contains(t, out, ch)
+	}
+	// Truncation indicator
+	assert.Contains(t, out, "...")
+	// Lines beyond the cap (k, l) should NOT appear as standalone values
+	lines := strings.Split(out, "\n")
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		// Skip lines that contain these letters as part of other words
+		if trimmed == "k" || trimmed == "l" {
+			t.Errorf("line %q should be truncated, but appeared in output", trimmed)
+		}
+	}
+}
+
+func TestCLI_MultilineDisabledEscapesNewlines(t *testing.T) {
+	// Temporarily disable multi-line rendering
+	orig := formatter.MaxValueLines()
+	formatter.SetMaxValueLines(0)
+	t.Cleanup(func() { formatter.SetMaxValueLines(orig) })
+
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-o", "table",
+	})
+	// With multi-line disabled, description should appear on a single row
+	// (value may be truncated by column width, but no continuation rows)
+	lines := strings.Split(out, "\n")
+	// Count how many lines contain "description" — should be exactly one
+	descCount := 0
+	for _, l := range lines {
+		if strings.Contains(l, "description") {
+			descCount++
+		}
+	}
+	assert.Equal(t, 1, descCount, "description should appear on exactly one row")
+	// "line two" should NOT appear on its own continuation row
+	var hasContinuation bool
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "line two" {
+			hasContinuation = true
+		}
+	}
+	assert.False(t, hasContinuation, "with multi-line disabled, 'line two' should not be a continuation row")
+}
+
+func TestCLI_MultilineUnlimitedShowsAllLines(t *testing.T) {
+	// Set unlimited mode
+	orig := formatter.MaxValueLines()
+	formatter.SetMaxValueLines(-1)
+	t.Cleanup(func() { formatter.SetMaxValueLines(orig) })
+
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-o", "table",
+	})
+	// "config" has 12 lines; unlimited should show all without "..."
+	assert.Contains(t, out, "config")
+	// All 12 lines should appear
+	for _, ch := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"} {
+		assert.Contains(t, out, ch)
+	}
+	// No truncation indicator
+	lines := strings.Split(out, "\n")
+	var hasTruncation bool
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "..." {
+			hasTruncation = true
+		}
+	}
+	assert.False(t, hasTruncation, "unlimited mode should not show truncation indicator")
+}
+
+func TestCLI_MultilineScalarExpression(t *testing.T) {
+	// When extracting a single multi-line scalar via expression, it should render
+	// with line breaks (raw scalar output)
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-e", "_.description",
+	})
+	expected := "line one\nline two\nline three\n"
+	assert.Equal(t, expected, out)
+}
+
+func TestCLI_MultilineConfigResetToDefault(t *testing.T) {
+	// When config omits max_value_lines, the global should reset to the default
+	// so a stale value from a previous run doesn't leak.
+	orig := formatter.MaxValueLines()
+	formatter.SetMaxValueLines(3) // simulate a previous run setting a custom cap
+	t.Cleanup(func() { formatter.SetMaxValueLines(orig) })
+
+	// Running the CLI without a config file should reset to the default (10)
+	out := runCLI(t, []string{
+		"kvx", filepath.Join("..", "tests", "multiline.json"),
+		"--no-color", "-o", "table",
+	})
+	assert.NotEmpty(t, out)
+	// After the CLI run, the global should have been reset to default
+	assert.Equal(t, formatter.DefaultMaxValueLines(), formatter.MaxValueLines())
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -24,6 +24,15 @@ var (
 	keyStyle       lipgloss.Style
 	valueStyle     lipgloss.Style
 	separatorStyle lipgloss.Style
+
+	// maxValueLines caps how many lines a multi-line value renders in
+	// the key-value table view. 0 disables multi-line (escapes newlines).
+	// Negative means unlimited. Default: 10.
+	maxValueLines = 10
+
+	// defaultMaxValueLines is the initial value of maxValueLines, used to
+	// reset the global when config omits the setting.
+	defaultMaxValueLines = 10
 )
 
 // TableColors controls the rendered colors for the formatter table.
@@ -68,6 +77,24 @@ func applyTableTheme(tc TableColors) {
 // fields to fall back to formatter defaults.
 func SetTableTheme(tc TableColors) {
 	applyTableTheme(tc)
+}
+
+// SetMaxValueLines sets the maximum number of lines rendered for multi-line
+// values in the key-value table view. 0 disables multi-line rendering
+// (newlines are escaped). Negative values mean unlimited.
+func SetMaxValueLines(n int) {
+	maxValueLines = n
+}
+
+// MaxValueLines returns the current multi-line value cap.
+func MaxValueLines() int {
+	return maxValueLines
+}
+
+// DefaultMaxValueLines returns the built-in default so callers can reset
+// the global when their configuration omits an explicit value.
+func DefaultMaxValueLines() int {
+	return defaultMaxValueLines
 }
 
 //nolint:gochecknoinits // initialize default table theme for package consumers
@@ -232,7 +259,7 @@ func CalculateNaturalTableWidth(rows [][]string) int {
 			}
 		}
 		if len(row) > 1 {
-			w := lipgloss.Width(row[1])
+			w := naturalValueWidth(row[1])
 			if w > maxValWidth {
 				maxValWidth = w
 			}
@@ -261,7 +288,7 @@ func RenderTableFitContent(rows [][]string, noColor bool, maxWidth int) string {
 			}
 		}
 		if len(row) > 1 {
-			w := lipgloss.Width(row[1])
+			w := naturalValueWidth(row[1])
 			if w > maxValWidth {
 				maxValWidth = w
 			}
@@ -323,12 +350,7 @@ func RenderTableFitContent(rows [][]string, noColor bool, maxWidth int) string {
 			val = row[1]
 		}
 		keyStr := padRight(truncate(key, keyWidth), keyWidth)
-		valStr := padRight(truncate(val, valueWidth), valueWidth)
-		if !noColor {
-			keyStr = keyStyle.Render(keyStr)
-			valStr = valueStyle.Render(valStr)
-		}
-		b.WriteString(keyStr + sep + valStr + "\n")
+		renderMultilineRow(&b, keyStr, val, keyWidth, valueWidth, noColor, sep)
 	}
 
 	return b.String()
@@ -390,22 +412,14 @@ func RenderTable(node any, noColor bool, keyColWidth, valueColWidth int) string 
 		for _, k := range keys {
 			v := t[k]
 			keyStr := padRight(truncate(k, keyWidth), keyWidth)
-			valStr := padRight(truncate(Stringify(v), valueWidth), valueWidth)
-			if !noColor {
-				keyStr = keyStyle.Render(keyStr)
-				valStr = valueStyle.Render(valStr)
-			}
-			b.WriteString(keyStr + sep + valStr + "\n")
+			valRaw := StringifyPreserveNewlines(v)
+			renderMultilineRow(&b, keyStr, valRaw, keyWidth, valueWidth, noColor, sep)
 		}
 	case []any:
 		for i, v := range t {
 			keyStr := padRight(fmt.Sprintf("[%d]", i), keyWidth)
-			valStr := padRight(truncate(Stringify(v), valueWidth), valueWidth)
-			if !noColor {
-				keyStr = keyStyle.Render(keyStr)
-				valStr = valueStyle.Render(valStr)
-			}
-			b.WriteString(keyStr + sep + valStr + "\n")
+			valRaw := StringifyPreserveNewlines(v)
+			renderMultilineRow(&b, keyStr, valRaw, keyWidth, valueWidth, noColor, sep)
 		}
 	default:
 		// Check if it's a slice type (could be []map, []string, etc.)
@@ -414,22 +428,14 @@ func RenderTable(node any, noColor bool, keyColWidth, valueColWidth int) string 
 			for i := 0; i < sliceVal.Len(); i++ {
 				v := sliceVal.Index(i).Interface()
 				keyStr := padRight(fmt.Sprintf("[%d]", i), keyWidth)
-				valStr := padRight(truncate(Stringify(v), valueWidth), valueWidth)
-				if !noColor {
-					keyStr = keyStyle.Render(keyStr)
-					valStr = valueStyle.Render(valStr)
-				}
-				b.WriteString(keyStr + sep + valStr + "\n")
+				valRaw := StringifyPreserveNewlines(v)
+				renderMultilineRow(&b, keyStr, valRaw, keyWidth, valueWidth, noColor, sep)
 			}
 		} else {
 			// scalar value - must match navigator.ScalarValueKey (can't import due to cycle)
 			keyStr := padRight("(value)", keyWidth)
-			valStr := padRight(truncate(Stringify(node), valueWidth), valueWidth)
-			if !noColor {
-				keyStr = keyStyle.Render(keyStr)
-				valStr = valueStyle.Render(valStr)
-			}
-			b.WriteString(keyStr + sep + valStr + "\n")
+			valRaw := StringifyPreserveNewlines(node)
+			renderMultilineRow(&b, keyStr, valRaw, keyWidth, valueWidth, noColor, sep)
 		}
 	}
 
@@ -484,15 +490,27 @@ func RenderRows(rows [][]string, noColor bool, keyColWidth, valueColWidth int) s
 			val = row[1]
 		}
 		keyStr := padRight(truncate(key, keyWidth), keyWidth)
-		valStr := padRight(truncate(val, valueWidth), valueWidth)
-		if !noColor {
-			keyStr = keyStyle.Render(keyStr)
-			valStr = valueStyle.Render(valStr)
-		}
-		b.WriteString(keyStr + sep + valStr + "\n")
+		renderMultilineRow(&b, keyStr, val, keyWidth, valueWidth, noColor, sep)
 	}
 
 	return b.String()
+}
+
+// naturalValueWidth returns the display width of a value as it will actually be
+// rendered. When multiline rendering is disabled (maxValueLines == 0) the value
+// is flattened with escaped newlines, so the width is measured from the flattened
+// form. Otherwise it returns the width of the widest individual line.
+func naturalValueWidth(val string) int {
+	if maxValueLines == 0 {
+		return lipgloss.Width(escapeScalarString(val))
+	}
+	best := 0
+	for _, line := range strings.Split(val, "\n") {
+		if w := lipgloss.Width(line); w > best {
+			best = w
+		}
+	}
+	return best
 }
 
 // padRight pads a string to the specified width, right-aligned
@@ -501,4 +519,60 @@ func padRight(s string, width int) string {
 		return s[:width]
 	}
 	return s + strings.Repeat(" ", width-len(s))
+}
+
+// renderMultilineRow writes a key-value row to b, splitting multi-line values
+// across multiple display rows. The first line appears next to the key; continuation
+// lines are indented to align under the value column with an empty key column.
+func renderMultilineRow(b *strings.Builder, keyStr, valRaw string, keyWidth, valueWidth int, noColor bool, sep string) {
+	// When multi-line rendering is disabled (maxValueLines == 0), flatten to single line.
+	if maxValueLines == 0 {
+		valFlat := padRight(truncate(escapeScalarString(valRaw), valueWidth), valueWidth)
+		k := keyStr
+		if !noColor {
+			k = keyStyle.Render(k)
+			valFlat = valueStyle.Render(valFlat)
+		}
+		b.WriteString(k + sep + valFlat + "\n")
+		return
+	}
+
+	lines := strings.Split(valRaw, "\n")
+	// Trim trailing empty line that YAML block scalars often leave
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Cap visible lines when a positive limit is set.
+	truncated := false
+	if maxValueLines > 0 && len(lines) > maxValueLines {
+		lines = lines[:maxValueLines]
+		truncated = true
+	}
+
+	for i, line := range lines {
+		var k string
+		if i == 0 {
+			k = keyStr
+		} else {
+			k = padRight("", keyWidth)
+		}
+		v := padRight(truncate(line, valueWidth), valueWidth)
+		if !noColor {
+			k = keyStyle.Render(k)
+			v = valueStyle.Render(v)
+		}
+		b.WriteString(k + sep + v + "\n")
+	}
+
+	// Show truncation indicator
+	if truncated {
+		k := padRight("", keyWidth)
+		v := padRight(truncate("...", valueWidth), valueWidth)
+		if !noColor {
+			k = keyStyle.Render(k)
+			v = valueStyle.Render(v)
+		}
+		b.WriteString(k + sep + v + "\n")
+	}
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
 
@@ -460,4 +461,176 @@ func TestRenderTable_Array(t *testing.T) {
 	if result == "" {
 		t.Fatal("expected non-empty output")
 	}
+}
+
+func TestRenderMultilineRow_SplitsLines(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(10)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	node := map[string]any{"msg": "line1\nline2\nline3"}
+	out := RenderTable(node, true, 10, 30)
+
+	assert.Contains(t, out, "line1")
+	assert.Contains(t, out, "line2")
+	assert.Contains(t, out, "line3")
+
+	// Continuation lines should not repeat the key
+	lines := strings.Split(out, "\n")
+	var keyCount int
+	for _, l := range lines {
+		if strings.Contains(l, "msg") {
+			keyCount++
+		}
+	}
+	assert.Equal(t, 1, keyCount, "key should appear once; continuation lines have blank key")
+}
+
+func TestRenderMultilineRow_DisabledEscapesNewlines(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(0)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	node := map[string]any{"msg": "line1\nline2"}
+	out := RenderTable(node, true, 10, 40)
+
+	// With multi-line disabled, value should be flattened with escaped newlines
+	assert.Contains(t, out, `line1\nline2`)
+	// No continuation row
+	lines := strings.Split(out, "\n")
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		assert.NotEqual(t, "line2", trimmed, "line2 should not appear as a separate row")
+	}
+}
+
+func TestRenderMultilineRow_TruncatesWithIndicator(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(3)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	node := map[string]any{"data": "a\nb\nc\nd\ne"}
+	out := RenderTable(node, true, 10, 20)
+
+	// First 3 lines should appear
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+	assert.Contains(t, out, "c")
+	// Truncation indicator
+	assert.Contains(t, out, "...")
+	// Lines beyond cap should not appear as standalone rows
+	lines := strings.Split(out, "\n")
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "d" || trimmed == "e" {
+			t.Errorf("line %q should be truncated", trimmed)
+		}
+	}
+}
+
+func TestRenderMultilineRow_UnlimitedShowsAll(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(-1)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	node := map[string]any{"data": "a\nb\nc\nd\ne"}
+	out := RenderTable(node, true, 10, 20)
+
+	for _, ch := range []string{"a", "b", "c", "d", "e"} {
+		assert.Contains(t, out, ch)
+	}
+	// No truncation indicator
+	lines := strings.Split(out, "\n")
+	for _, l := range lines {
+		assert.NotEqual(t, "...", strings.TrimSpace(l))
+	}
+}
+
+func TestNaturalValueWidth_FlattenedWhenDisabled(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(0)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	// "a\nb" flattened to "a\\nb" has width 4
+	w := naturalValueWidth("a\nb")
+	assert.Equal(t, 4, w)
+}
+
+func TestNaturalValueWidth_WidestLineWhenEnabled(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(10)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	// Widest line is "hello" (5)
+	w := naturalValueWidth("hi\nhello\nbye")
+	assert.Equal(t, 5, w)
+}
+
+func TestDefaultMaxValueLines(t *testing.T) {
+	assert.Equal(t, 10, DefaultMaxValueLines())
+}
+
+func TestRenderMultilineRow_ColorBranches(t *testing.T) {
+	// Exercise the noColor=false paths in renderMultilineRow
+	orig := MaxValueLines()
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	// Enabled mode with color
+	SetMaxValueLines(10)
+	node := map[string]any{"key": "a\nb"}
+	out := RenderTable(node, false, 10, 20)
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+
+	// Disabled mode with color
+	SetMaxValueLines(0)
+	out = RenderTable(node, false, 10, 30)
+	assert.Contains(t, out, `a\nb`)
+
+	// Truncation with color
+	SetMaxValueLines(2)
+	node2 := map[string]any{"k": "x\ny\nz\nw"}
+	out = RenderTable(node2, false, 10, 20)
+	assert.Contains(t, out, "...")
+}
+
+func TestRenderMultilineRow_TrailingEmptyLineTrimmed(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(10)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	// YAML block scalars often have a trailing newline -> trailing empty line
+	node := map[string]any{"note": "line1\nline2\n"}
+	out := RenderTable(node, true, 10, 20)
+	// Should show 2 lines, not 3 (trailing empty trimmed)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	var valueLines int
+	for _, l := range lines[2:] { // skip header + separator
+		if strings.TrimSpace(l) != "" {
+			valueLines++
+		}
+	}
+	assert.Equal(t, 2, valueLines, "trailing empty line should be trimmed")
+}
+
+func TestRenderRows_ColorBranches(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(10)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	rows := [][]string{{"key", "a\nb"}}
+	out := RenderRows(rows, false, 10, 20)
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+}
+
+func TestRenderTableFitContent_ColorBranches(t *testing.T) {
+	orig := MaxValueLines()
+	SetMaxValueLines(10)
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	rows := [][]string{{"key", "a\nb"}}
+	out := RenderTableFitContent(rows, false, 0)
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
 }

--- a/internal/navigator/navigator.go
+++ b/internal/navigator/navigator.go
@@ -422,7 +422,7 @@ func NodeToRowsWithOptions(node interface{}, opts RowOptions) [][]string {
 	case map[string]interface{}:
 		// Treat empty maps as scalar values
 		if len(t) == 0 {
-			rows = append(rows, []string{ScalarValueKey, formatter.Stringify(node)})
+			rows = append(rows, []string{ScalarValueKey, formatter.StringifyPreserveNewlines(node)})
 			return rows
 		}
 		keys := make([]string, 0, len(t))
@@ -439,23 +439,23 @@ func NodeToRowsWithOptions(node interface{}, opts RowOptions) [][]string {
 		}
 		for _, k := range keys {
 			v := t[k]
-			rows = append(rows, []string{k, formatter.Stringify(v)})
+			rows = append(rows, []string{k, formatter.StringifyPreserveNewlines(v)})
 		}
 	case []interface{}:
 		// Treat empty arrays as scalar values
 		if len(t) == 0 {
-			rows = append(rows, []string{ScalarValueKey, formatter.Stringify(node)})
+			rows = append(rows, []string{ScalarValueKey, formatter.StringifyPreserveNewlines(node)})
 			return rows
 		}
 		for i, v := range t {
 			key := formatArrayIndex(i, opts.ArrayStyle)
-			rows = append(rows, []string{key, formatter.Stringify(v)})
+			rows = append(rows, []string{key, formatter.StringifyPreserveNewlines(v)})
 		}
 	default:
 		rv := reflect.ValueOf(node)
 		if rv.Kind() == reflect.Map && rv.IsValid() && rv.Type().Key().Kind() == reflect.String {
 			if rv.Len() == 0 {
-				rows = append(rows, []string{ScalarValueKey, formatter.Stringify(node)})
+				rows = append(rows, []string{ScalarValueKey, formatter.StringifyPreserveNewlines(node)})
 				return rows
 			}
 			keys := make([]string, 0, rv.Len())
@@ -472,7 +472,7 @@ func NodeToRowsWithOptions(node interface{}, opts RowOptions) [][]string {
 			}
 			for _, k := range keys {
 				value := rv.MapIndex(reflect.ValueOf(k)).Interface()
-				rows = append(rows, []string{k, formatter.Stringify(value)})
+				rows = append(rows, []string{k, formatter.StringifyPreserveNewlines(value)})
 			}
 			return rows
 		}
@@ -481,10 +481,10 @@ func NodeToRowsWithOptions(node interface{}, opts RowOptions) [][]string {
 			for i := 0; i < rv.Len(); i++ {
 				v := rv.Index(i).Interface()
 				key := formatArrayIndex(i, opts.ArrayStyle)
-				rows = append(rows, []string{key, formatter.Stringify(v)})
+				rows = append(rows, []string{key, formatter.StringifyPreserveNewlines(v)})
 			}
 		} else {
-			rows = append(rows, []string{ScalarValueKey, formatter.Stringify(node)})
+			rows = append(rows, []string{ScalarValueKey, formatter.StringifyPreserveNewlines(node)})
 		}
 	}
 	return rows

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -308,8 +308,9 @@ type FeaturesConfig struct {
 
 // DisplayConfig holds display and layout settings.
 type DisplayConfig struct {
-	KeyColWidth *int    `yaml:"key_col_width,omitempty" yamlcomment:"Width of the KEY column (default: 30)"`
-	Sort        *string `yaml:"sort,omitempty" yamlcomment:"Sort order for map keys: none|ascending|descending"`
+	KeyColWidth   *int    `yaml:"key_col_width,omitempty" yamlcomment:"Width of the KEY column (default: 30)"`
+	ValueColWidth *int    `yaml:"value_col_width,omitempty" yamlcomment:"Width of the VALUE column (default: auto)"`
+	Sort          *string `yaml:"sort,omitempty" yamlcomment:"Sort order for map keys: none|ascending|descending"`
 }
 
 // BehaviorConfig holds user behavior and interaction settings.
@@ -368,6 +369,11 @@ type TableFormattingConfig struct {
 
 	// HiddenColumns specifies columns to omit from columnar tables.
 	HiddenColumns []string `yaml:"hidden_columns,omitempty" yamlcomment:"Columns to hide in columnar display"`
+
+	// MaxValueLines caps how many lines a multi-line value renders in the
+	// key-value table view. 0 disables multi-line (escapes newlines).
+	// Negative means unlimited. Default: 10.
+	MaxValueLines *int `yaml:"max_value_lines,omitempty" yamlcomment:"Max lines for multi-line values (0=disable, -1=unlimited, default: 10)"`
 
 	// SchemaFile is a path to a JSON Schema file used to derive column display hints.
 	SchemaFile *string `yaml:"schema_file,omitempty" yamlcomment:"JSON Schema file for column display hints"`

--- a/pkg/tui/panel.go
+++ b/pkg/tui/panel.go
@@ -53,6 +53,21 @@ const (
 	FormatAuto OutputFormat = "auto"
 )
 
+// SetMaxValueLines sets the default maximum number of lines rendered for
+// multi-line values in the key-value table view. 0 disables multi-line
+// rendering (newlines are escaped). Negative values mean unlimited.
+// The default is 10.
+//
+// This can be overridden per-call via [TableOptions.MaxValueLines].
+func SetMaxValueLines(n int) {
+	formatter.SetMaxValueLines(n)
+}
+
+// MaxValueLines returns the current default multi-line value line cap.
+func MaxValueLines() int {
+	return formatter.MaxValueLines()
+}
+
 // PanelOptions configures data panel rendering.
 //
 // Deprecated: Use TableOptions instead.
@@ -154,6 +169,12 @@ type TableOptions struct {
 	// Keys are the original field names in the data. Use [ParseSchema] to derive hints
 	// from a JSON Schema, or construct directly for programmatic control.
 	ColumnHints map[string]ColumnHint
+
+	// MaxValueLines caps how many lines a multi-line string value renders
+	// in the key-value table view. If nil, the package-level default is used
+	// (initially 10). A non-nil pointer to 0 disables multiline rendering.
+	// Set to -1 for unlimited, or a positive number to cap at that many lines.
+	MaxValueLines *int
 }
 
 // RenderTable renders a two-column key/value table for the given node.
@@ -175,6 +196,16 @@ func RenderTable(node any, opts TableOptions) string {
 		ValueColor:     th.ValueColor,
 		SeparatorColor: th.SeparatorColor,
 	})
+
+	// Apply per-call MaxValueLines override if provided.
+	// NOTE: This temporarily mutates the package-level formatter global and is
+	// not safe for concurrent use. Callers must serialise RenderTable calls
+	// when using per-call overrides.
+	if opts.MaxValueLines != nil {
+		prev := formatter.MaxValueLines()
+		formatter.SetMaxValueLines(*opts.MaxValueLines)
+		defer formatter.SetMaxValueLines(prev)
+	}
 
 	// Auto-detect terminal width if not specified
 	termWidth := opts.Width

--- a/pkg/tui/panel_test.go
+++ b/pkg/tui/panel_test.go
@@ -625,3 +625,38 @@ func TestRender_AutoFormat(t *testing.T) {
 	assert.Contains(t, out, "key")
 	assert.Contains(t, out, "value")
 }
+
+func TestSetMaxValueLines_RoundTrip(t *testing.T) {
+	orig := MaxValueLines()
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	SetMaxValueLines(5)
+	assert.Equal(t, 5, MaxValueLines())
+
+	SetMaxValueLines(0)
+	assert.Equal(t, 0, MaxValueLines())
+
+	SetMaxValueLines(-1)
+	assert.Equal(t, -1, MaxValueLines())
+}
+
+func TestRenderTable_PerCallMaxValueLines(t *testing.T) {
+	orig := MaxValueLines()
+	t.Cleanup(func() { SetMaxValueLines(orig) })
+
+	SetMaxValueLines(10) // global default
+
+	// Per-call override: disable multiline
+	zero := 0
+	node := map[string]any{"msg": "a\nb"}
+	out := RenderTable(node, TableOptions{
+		NoColor:       true,
+		Width:         80,
+		MaxValueLines: &zero,
+	})
+	// With maxValueLines=0, newlines should be escaped
+	assert.Contains(t, out, `a\nb`)
+
+	// Global should be restored after RenderTable returns
+	assert.Equal(t, 10, MaxValueLines())
+}

--- a/tests/multiline.json
+++ b/tests/multiline.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-app",
+  "description": "line one\nline two\nline three",
+  "config": "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl"
+}


### PR DESCRIPTION
Display multi-line string values with actual line breaks instead of escaped \n in the key-value table view, with configurable line cap.

- Add renderMultilineRow() helper in internal/formatter/formatter.go that splits values across rows with continuation lines aligned under the value column
- Add maxValueLines package-level setting (default: 10) with SetMaxValueLines()/MaxValueLines() getter/setter
- Support 0 (disable, escape newlines), -1 (unlimited), or positive cap with "..." truncation indicator
- Update RenderTable, RenderRows, RenderTableFitContent to use renderMultilineRow with StringifyPreserveNewlines
- Change NodeToRowsWithOptions to use StringifyPreserveNewlines (NodeToRows for TUI remains unchanged)
- Add max_value_lines to formatting.table config section
- Add value_col_width to display config section
- Wire config values through CLI in cmd/root.go
- Expose tui.SetMaxValueLines()/MaxValueLines() and per-call TableOptions.MaxValueLines for library consumers