### PR TITLE
fix(ui): disable multi-line value rendering in interactive table view

### DIFF
--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -395,3 +395,29 @@ func TestRenderPanelLayout_HelpPopupOverridesHelpText(t *testing.T) {
 		t.Fatalf("expected base help text to be suppressed when popup is present")
 	}
 }
+
+func TestRenderPanelLayout_MultilineValueEscaped(t *testing.T) {
+	// Multi-line values must be escaped (shown as \n) in the interactive table
+	// so cursor/selection tracks one logical row per key.
+	state := PanelLayoutState{
+		WinWidth:    100,
+		WinHeight:   30,
+		Title:       "kvx",
+		DisplayNode: map[string]any{"msg": "line1\nline2\nline3"},
+		RowCount:    1,
+		SelectedRow: 0,
+		PathLabel:   "_",
+		KeyColWidth: DefaultKeyColWidth,
+		NoColor:     true,
+	}
+
+	output := RenderPanelLayout(state)
+	if !strings.Contains(output, `\n`) {
+		t.Fatalf("expected escaped newlines (\\n) in interactive table, got:\n%s", output)
+	}
+	// The value should NOT be split across multiple rows.
+	// Count occurrences of "msg" — should appear exactly once.
+	if strings.Count(output, "msg") != 1 {
+		t.Fatalf("expected exactly one row for 'msg' key, got multiple:\n%s", output)
+	}
+}

--- a/internal/ui/panel_layout.go
+++ b/internal/ui/panel_layout.go
@@ -240,6 +240,12 @@ func RenderPanelLayout(state PanelLayoutState) string {
 			ValueColor:     th.ValueColor,
 			SeparatorColor: th.SeparatorColor,
 		})
+		// Disable multi-line value rendering for the interactive table.
+		// The TUI cursor tracks logical rows (one per key), so multi-line
+		// expansion would break selection highlighting and navigation.
+		prevLines := formatter.MaxValueLines()
+		formatter.SetMaxValueLines(0)
+		defer formatter.SetMaxValueLines(prevLines)
 		tableText = formatter.RenderTable(displayNode, state.NoColor, keyColWidth, availableForValues)
 		// Clamp to the inner content width (panel width minus borders) to prevent wrapping.
 		// Clamp with +2 to preserve all three ellipsis dots that truncate() adds.


### PR DESCRIPTION
The TUI cursor tracks logical rows (one per key), so multi-line value expansion broke selection highlighting and navigation. Temporarily set maxValueLines=0 around the formatter.RenderTable call in the interactive panel layout to keep one visual line per logical row. Non-interactive CLI output is unaffected.