### PR TITLE
fix(formatter): prevent false column truncation in readability

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -912,9 +912,11 @@ func renderColumnarBorderedTable(node interface{}, noColor bool, widthHint int, 
 	showRowNum := tableOpts.ArrayStyle != "none"
 	naturalContentWidth := formatter.CalculateNaturalColumnarWidthWithHints(columns, rows, showRowNum, len(rows), tableOpts.ColumnHints, tableOpts.HiddenColumns)
 
-	// Table width: use natural width if it fits, otherwise use terminal width
+	// Table width: use natural width if it fits, otherwise use terminal width.
+	// When any column has Flex: true, always fill the terminal width so that
+	// flex columns can absorb the surplus space.
 	tableWidth := termWidth
-	if naturalContentWidth+2 < termWidth {
+	if naturalContentWidth+2 < termWidth && !formatter.HasFlexColumn(tableOpts.ColumnHints) {
 		// Content fits naturally - use fit-to-content width
 		tableWidth = naturalContentWidth + 2
 	}
@@ -1414,6 +1416,8 @@ func tableFormatOptionsFromConfig(cfg ui.ThemeConfigFile) formatter.TableFormatO
 				Priority:    h.Priority,
 				Align:       h.Align,
 				DisplayName: h.DisplayName,
+				Hidden:      h.Hidden,
+				Flex:        h.Flex,
 			}
 			if h.Hidden {
 				opts.HiddenColumns = append(opts.HiddenColumns, k)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -462,7 +462,9 @@ func TestCLI_SchemaAppliesColumnHints(t *testing.T) {
 	})
 
 	t.Run("maxLength caps column width", func(t *testing.T) {
-		// Create a schema with maxLength on full_name
+		// Create a schema with maxLength on full_name using a short title
+		// so the header doesn't widen beyond the cap (MaxWidth floors at
+		// header width to prevent header truncation).
 		schemaWithMax := filepath.Join(tmpDir, "schema_max.json")
 		err := os.WriteFile(schemaWithMax, []byte(`{
 			"type": "array",
@@ -471,6 +473,7 @@ func TestCLI_SchemaAppliesColumnHints(t *testing.T) {
 				"properties": {
 					"full_name": {
 						"type": "string",
+						"title": "Name",
 						"maxLength": 4
 					}
 				}
@@ -480,6 +483,7 @@ func TestCLI_SchemaAppliesColumnHints(t *testing.T) {
 
 		out := runCLI(t, []string{"kvx", dataFile, "--no-color", "--schema", schemaWithMax, "-o", "table"})
 		// "Alice" (5 chars) should be truncated to 4 chars by maxLength cap
+		// (title "Name" = 4 chars, so MaxWidth stays at 4)
 		require.NotContains(t, out, "Alice", "full_name should be truncated by maxLength 4; output:\n%s", out)
 	})
 }
@@ -2411,8 +2415,9 @@ func TestCLI_MultilineConfigResetToDefault(t *testing.T) {
 }
 
 func TestCLI_AutoDropsColumnsNarrowWidth(t *testing.T) {
-	// At narrow width with schema hints, auto mode should drop low-priority
-	// columns instead of falling back to list view.
+	// At narrow width with schema hints, auto mode renders a table.
+	// full_name has no maxLength, so ParseSchema marks it Flex — the flex
+	// column absorbs the squeeze and non-flex columns retain their width.
 	out := runCLI(t, []string{
 		"kvx", filepath.Join("..", "examples", "data", "users.json"),
 		"--schema", filepath.Join("..", "examples", "data", "users_schema.json"),
@@ -2421,8 +2426,9 @@ func TestCLI_AutoDropsColumnsNarrowWidth(t *testing.T) {
 	// High-priority columns (required: user_id, full_name) should survive
 	assert.Contains(t, out, "ID")
 	assert.Contains(t, out, "Name")
-	// Low-priority columns should be dropped to fit
-	assert.NotContains(t, out, "Dept")
+	// With flex, Dept (non-flex, enum-constrained) also survives because
+	// the flex column (Name) absorbs the width squeeze.
+	assert.Contains(t, out, "Dept")
 }
 
 func TestCLI_AutoFallsBackToListExtremeNarrow(t *testing.T) {

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -251,6 +251,49 @@ output := tui.RenderTable(root, tui.TableOptions{
 | `deprecated: true` | `Hidden: true` |
 | `required` array | `Priority` boost |
 
+### Flex columns (fill terminal width)
+
+By default, bordered tables shrink to fit the natural content width. When you want
+one or more columns to absorb remaining terminal space (e.g. a "message" or
+"description" column), mark them with `Flex: true`:
+
+```go
+hints := map[string]tui.ColumnHint{
+    "severity": {MaxWidth: 8, Priority: 10},
+    "message":  {Flex: true},  // absorbs remaining terminal width
+}
+
+output := tui.RenderTable(root, tui.TableOptions{
+    Bordered:    true,
+    ColumnHints: hints,
+})
+```
+
+Key behaviors:
+
+- When any column has `Flex: true`, the bordered table fills the full terminal width
+  instead of shrinking to content.
+- Surplus space is distributed evenly among flex columns.
+- `MaxWidth` acts as a minimum guarantee for flex columns during initial sizing,
+  not a cap on expansion. Flex columns start at `MaxWidth` (if set) and grow to
+  fill remaining space.
+- Non-flex columns keep their natural (content-fitted) width.
+- If no column is marked `Flex`, behavior is unchanged (fit-to-content).
+
+### Calculating table overhead
+
+In most cases you do not need to calculate overhead manually -- use `Flex: true`
+and let kvx handle the layout math internally.
+
+For advanced use cases where you need to compute available content width (e.g.
+to set a dynamic `MaxWidth`), the overhead formula is:
+
+~~~
+overhead = 2 (borders) + (numCols - 1) * 2 (separators)
+~~~
+
+Add the row-number column width if row numbers are enabled.
+
 ### Unified `Render` function
 
 If you want to let the caller choose the output format at runtime (table, list, YAML, JSON),
@@ -412,3 +455,21 @@ tui.Run(root, cfg)
 | `tui.NewCELExpressionProvider(env, hints)` | Create an expression provider from a CEL env |
 | `tui.SetExpressionProvider(p)` | Override the global expression provider |
 | `tui.ResetExpressionProvider()` | Restore the default provider |
+
+### `tui.ColumnHint` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `MaxWidth` | `int` | Cap column width (0 = no cap). For flex columns, acts as a minimum guarantee — the column starts at MaxWidth but can expand beyond it |
+| `Priority` | `int` | Column importance during shrinking (higher = resists more) |
+| `DisplayName` | `string` | Override column header text |
+| `Align` | `string` | `"right"` or `"left"` (default) |
+| `Hidden` | `bool` | Omit column from output |
+| `Flex` | `bool` | Absorb remaining terminal width after fixed columns. Auto-set by `ParseSchema` for columns without `maxLength`/`enum`/`format` constraints |
+
+### `internal/formatter` (advanced)
+
+| Function | Description |
+|---|---|
+| `formatter.ColumnarOverhead(numCols, showRowNum, numRows)` | Calculate fixed overhead (borders + separators + row numbers) |
+| `formatter.HasFlexColumn(hints)` | Check if any hint has `Flex: true` |

--- a/examples/solutions/findings_schema.json
+++ b/examples/solutions/findings_schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["severity", "message"],
+    "properties": {
+      "severity": {
+        "type": "string",
+        "title": "Sev",
+        "enum": ["error", "warn", "info"]
+      },
+      "message": {
+        "type": "string",
+        "title": "Message"
+      },
+      "category": {
+        "type": "string",
+        "title": "Cat",
+        "maxLength": 10
+      },
+      "location": {
+        "type": "string",
+        "title": "Location",
+        "maxLength": 30
+      },
+      "ruleName": {
+        "type": "string",
+        "title": "Rule",
+        "maxLength": 20
+      },
+      "suggestion": {
+        "type": "string",
+        "title": "Fix"
+      }
+    }
+  }
+}

--- a/internal/formatter/column_hint.go
+++ b/internal/formatter/column_hint.go
@@ -17,4 +17,16 @@ type ColumnHint struct {
 	// DisplayName overrides the column header text.
 	// Empty string means use the original field name.
 	DisplayName string
+
+	// Hidden marks this column as hidden. Hidden columns are never rendered
+	// and are excluded from layout decisions like flex detection.
+	Hidden bool
+
+	// Flex marks this column as a flex column that absorbs remaining
+	// space after fixed columns are allocated. When the table has more
+	// room than the natural content width, flex columns expand to fill
+	// the terminal width. MaxWidth acts as a minimum guarantee during
+	// initial sizing, not a cap on expansion.
+	// If no column is marked Flex, columns keep their natural width.
+	Flex bool
 }

--- a/internal/formatter/columnar.go
+++ b/internal/formatter/columnar.go
@@ -303,7 +303,6 @@ func calculateColumnWidths(columns []string, rows [][]string, availableWidth int
 	}
 
 	const sepWidth = 2
-	const minColWidth = 3
 	widths := make([]int, numCols)
 	for i, col := range columns {
 		widths[i] = lipgloss.Width(col)
@@ -332,6 +331,25 @@ func calculateColumnWidths(columns []string, rows [][]string, availableWidth int
 	totalSeps := (numCols - 1) * sepWidth
 	usableWidth := availableWidth - totalSeps
 
+	// Separate flex and non-flex columns. Flex columns are sized to
+	// their header width during the shrink phase; they receive whatever
+	// remains via distributeSurplus afterward.
+	var flexIdxs []int
+	if len(hints) > 0 {
+		for i := range hints {
+			if i < numCols && hints[i].Flex {
+				flexIdxs = append(flexIdxs, i)
+				// Reduce flex columns to header width for the shrink phase.
+				// This prevents their content from inflating totalNeeded
+				// and squeezing non-flex columns.
+				widths[i] = lipgloss.Width(columns[i])
+				if hints[i].MaxWidth > 0 && widths[i] < hints[i].MaxWidth {
+					widths[i] = hints[i].MaxWidth
+				}
+			}
+		}
+	}
+
 	// Calculate total needed
 	totalNeeded := 0
 	for _, w := range widths {
@@ -344,60 +362,84 @@ func calculateColumnWidths(columns []string, rows [][]string, availableWidth int
 			// Priority-based shrinking: shrink lowest-priority columns first
 			widths = shrinkByPriority(widths, usableWidth, hints)
 		} else {
-			// Original behavior: cap then proportional shrink
-			maxColWidth := 40
-			for i := range widths {
-				if widths[i] > maxColWidth {
-					widths[i] = maxColWidth
-				}
-			}
-
-			totalNeeded = 0
-			for _, w := range widths {
-				totalNeeded += w
-			}
-
-			if totalNeeded > usableWidth {
-				totalOriginal := 0
-				for _, w := range widths {
-					totalOriginal += w
-				}
-
-				for i := range widths {
-					proportion := float64(widths[i]) / float64(totalOriginal)
-					newWidth := int(proportion * float64(usableWidth))
-					if newWidth < minColWidth {
-						newWidth = minColWidth
-					}
-					widths[i] = newWidth
-				}
-
-				// Final adjustment: ensure total doesn't exceed usableWidth
-				for {
-					total := 0
-					for _, w := range widths {
-						total += w
-					}
-					if total <= usableWidth {
-						break
-					}
-					maxIdx := 0
-					for i := 1; i < numCols; i++ {
-						if widths[i] > widths[maxIdx] {
-							maxIdx = i
-						}
-					}
-					if widths[maxIdx] > minColWidth {
-						widths[maxIdx]--
-					} else {
-						break
-					}
-				}
-			}
+			widths = shrinkProportional(widths, usableWidth)
 		}
 	}
 
+	// Distribute surplus space to flex columns.
+	if surplus := usableWidth - totalUsed(widths); surplus > 0 && len(flexIdxs) > 0 {
+		distributeSurplus(widths, flexIdxs, surplus)
+	}
+
 	return widths
+}
+
+// totalUsed returns the sum of all column widths.
+func totalUsed(widths []int) int {
+	t := 0
+	for _, w := range widths {
+		t += w
+	}
+	return t
+}
+
+// distributeSurplus distributes extra space evenly among flex columns.
+// Flex columns expand freely — MaxWidth is treated as a minimum guarantee
+// (already applied during initial sizing), not a cap on expansion.
+func distributeSurplus(widths []int, flexIdxs []int, surplus int) {
+	if len(flexIdxs) == 0 {
+		return
+	}
+	remaining := surplus
+	for remaining > 0 {
+		share := remaining / len(flexIdxs)
+		if share == 0 {
+			share = 1
+		}
+		for _, idx := range flexIdxs {
+			if remaining <= 0 {
+				break
+			}
+			add := share
+			if add > remaining {
+				add = remaining
+			}
+			widths[idx] += add
+			remaining -= add
+		}
+	}
+}
+
+// HasFlexColumn reports whether any visible (non-hidden) hint has Flex set.
+// Hidden columns are excluded because they are never rendered and should not
+// influence table width decisions.
+func HasFlexColumn(hints map[string]ColumnHint) bool {
+	for _, h := range hints {
+		if h.Flex && !h.Hidden {
+			return true
+		}
+	}
+	return false
+}
+
+// ColumnarOverhead returns the fixed character overhead for a columnar table
+// with borders: 2 for side borders + 2 per inter-column separator.
+// Callers can use this to compute available content width:
+//
+//	contentWidth = termWidth - ColumnarOverhead(numCols, showRowNum, numRows)
+func ColumnarOverhead(numCols int, showRowNum bool, numRows int) int {
+	const sepWidth = 2
+	const borderWidth = 2 // left + right border characters
+
+	overhead := borderWidth
+	if numCols > 1 {
+		overhead += (numCols - 1) * sepWidth
+	}
+	if showRowNum && numCols > 0 {
+		rowNumWidth := len(fmt.Sprintf("%d", numRows)) + 2
+		overhead += rowNumWidth + sepWidth
+	}
+	return overhead
 }
 
 func renderHeader(columns []string, widths []int, sepWidth, rowNumWidth int, showRowNum, noColor bool) string {
@@ -554,6 +596,135 @@ func shrinkByPriority(widths []int, usableWidth int, hints []ColumnHint) []int {
 	return widths
 }
 
+// defaultMaxColWidth is the initial cap applied to columns before proportional
+// shrinking. It prevents a single column from dominating the entire table width.
+const defaultMaxColWidth = 40
+
+// shrinkProportional reduces column widths to fit within usableWidth using
+// proportional allocation. Columns whose natural width already fits within a
+// fair share are preserved at their natural size, and only wider columns are
+// shrunk. This prevents short columns (e.g. "severity"=8) from being truncated
+// while longer columns still have unused padding.
+func shrinkProportional(naturalWidths []int, usableWidth int) []int {
+	const minColWidth = 3
+	numCols := len(naturalWidths)
+	widths := make([]int, numCols)
+	copy(widths, naturalWidths)
+
+	// Cap excessively wide columns first
+	for i := range widths {
+		if widths[i] > defaultMaxColWidth {
+			widths[i] = defaultMaxColWidth
+		}
+	}
+
+	if totalUsed(widths) <= usableWidth {
+		return widths
+	}
+
+	// Two-pass approach: lock columns that fit at natural size, shrink the rest.
+	// A column "fits" if its natural (capped) width is at or below the fair
+	// share (usableWidth / numCols). Locked columns keep their natural width;
+	// the remaining space is distributed proportionally among the rest.
+	//
+	// Guard: if locking would leave unlocked columns with less than
+	// minReadableWidth each, skip locking entirely and shrink all columns
+	// proportionally. This prevents narrow-but-locked columns from starving
+	// wider columns below the readability threshold.
+	fairShare := usableWidth / numCols
+	locked := make([]bool, numCols)
+	lockedTotal := 0
+	unlocked := 0
+	for i, w := range widths {
+		if w <= fairShare {
+			locked[i] = true
+			lockedTotal += w
+		} else {
+			unlocked++
+		}
+	}
+
+	// If locking would starve unlocked columns, fall back to full proportional.
+	if unlocked > 0 {
+		perUnlocked := (usableWidth - lockedTotal) / unlocked
+		if perUnlocked < minReadableWidth {
+			// Reset: treat all columns as unlocked
+			for i := range locked {
+				locked[i] = false
+			}
+			lockedTotal = 0
+			unlocked = numCols
+		}
+	}
+
+	if unlocked == 0 {
+		// All columns are at or below fair share — shouldn't happen since
+		// total > usableWidth, but handle it gracefully with equal split.
+		each := usableWidth / numCols
+		for i := range widths {
+			widths[i] = each
+			if widths[i] < minColWidth {
+				widths[i] = minColWidth
+			}
+		}
+		return widths
+	}
+
+	remainingWidth := usableWidth - lockedTotal
+	// Distribute remaining space proportionally among unlocked columns
+	unlockedTotal := 0
+	for i := range widths {
+		if !locked[i] {
+			unlockedTotal += widths[i]
+		}
+	}
+	for i := range widths {
+		if locked[i] {
+			continue
+		}
+		proportion := float64(widths[i]) / float64(unlockedTotal)
+		widths[i] = int(proportion * float64(remainingWidth))
+		if widths[i] < minColWidth {
+			widths[i] = minColWidth
+		}
+	}
+
+	adjustRounding(widths, locked, usableWidth, minColWidth)
+
+	return widths
+}
+
+// adjustRounding corrects rounding errors from proportional allocation by
+// adding to or removing from the widest unlocked columns until the total
+// matches targetWidth exactly.
+func adjustRounding(widths []int, locked []bool, targetWidth, minWidth int) {
+	for totalUsed(widths) < targetWidth {
+		bestIdx := -1
+		for i := range widths {
+			if !locked[i] && (bestIdx == -1 || widths[i] > widths[bestIdx]) {
+				bestIdx = i
+			}
+		}
+		if bestIdx == -1 {
+			break
+		}
+		widths[bestIdx]++
+	}
+
+	for totalUsed(widths) > targetWidth {
+		maxIdx := -1
+		for i := range widths {
+			if !locked[i] && (maxIdx == -1 || widths[i] > widths[maxIdx]) {
+				maxIdx = i
+			}
+		}
+		if maxIdx == -1 || widths[maxIdx] <= minWidth {
+			break
+		}
+		widths[maxIdx]--
+	}
+}
+
 // minReadableWidth is the minimum column width before data becomes unreadable.
 // Below this, columns show mostly ellipsis (e.g. "ab...") which is useless.
 const minReadableWidth = 8
@@ -606,10 +777,17 @@ func IsColumnarReadable(columns []string, rows [][]string, availableWidth int, h
 		return false
 	}
 
-	// Calculate natural widths to know each column's unconstrained size
+	// Build display column names matching the renderer so that natural
+	// width calculations and assigned widths are consistent.
+	displayCols := make([]string, len(visibleCols))
 	naturalWidths := make([]int, len(visibleCols))
 	for i, col := range visibleCols {
-		naturalWidths[i] = lipgloss.Width(col)
+		header := col
+		if h, ok := hints[col]; ok && h.DisplayName != "" {
+			header = h.DisplayName
+		}
+		displayCols[i] = header
+		naturalWidths[i] = lipgloss.Width(header)
 	}
 	for _, row := range visibleRows {
 		for i, val := range row {
@@ -618,6 +796,16 @@ func IsColumnarReadable(columns []string, rows [][]string, availableWidth int, h
 					naturalWidths[i] = w
 				}
 			}
+		}
+	}
+
+	// Cap naturalWidths at MaxWidth when set: columns with a MaxWidth
+	// hint are intentionally narrow (e.g. enum-only fields), so their
+	// effective natural width for readability purposes is the cap, not
+	// the header width.
+	for i, col := range visibleCols {
+		if h, ok := hints[col]; ok && h.MaxWidth > 0 && naturalWidths[i] > h.MaxWidth {
+			naturalWidths[i] = h.MaxWidth
 		}
 	}
 
@@ -632,12 +820,20 @@ func IsColumnarReadable(columns []string, rows [][]string, availableWidth int, h
 		}
 	}
 
-	// Calculate assigned widths using the same algorithm the renderer uses
-	assigned := calculateColumnWidths(visibleCols, visibleRows, effectiveWidth, hintSlice)
+	// Calculate assigned widths using the same algorithm the renderer uses.
+	// Pass displayCols so header widths match the renderer exactly.
+	assigned := calculateColumnWidths(displayCols, visibleRows, effectiveWidth, hintSlice)
 
-	// Check if any column that naturally needs more than minReadableWidth
-	// was shrunk below that threshold
+	// A column is unreadable when its allocated width drops below
+	// minReadableWidth. We only flag columns whose content naturally
+	// needs that much space; tiny columns (e.g. "ok"/"yn") are fine
+	// at narrow widths. Flex columns are skipped entirely — they are
+	// designed to accept whatever width remains after fixed columns
+	// are allocated, so they should never trigger a list fallback.
 	for i, w := range assigned {
+		if len(hintSlice) > i && hintSlice[i].Flex {
+			continue
+		}
 		if naturalWidths[i] >= minReadableWidth && w < minReadableWidth {
 			return false
 		}

--- a/internal/formatter/columnar_test.go
+++ b/internal/formatter/columnar_test.go
@@ -188,6 +188,169 @@ func TestCalculateColumnWidths_WithHints(t *testing.T) {
 		assert.Greater(t, widths[0], widths[1],
 			"higher-priority column should retain more width")
 	})
+
+	t.Run("flex column absorbs surplus", func(t *testing.T) {
+		columns := []string{"status", "message"}
+		rows := [][]string{
+			{"ok", "short msg"},
+		}
+		hints := []ColumnHint{
+			{},           // status - fixed
+			{Flex: true}, // message - flex
+		}
+
+		// Natural widths: status=6("status"), message=9("short msg")
+		// Total natural = 6+9 = 15, seps = 2, so 17 needed.
+		// Give 60 chars available → 43 surplus should go to message.
+		widths := calculateColumnWidths(columns, rows, 60, hints)
+		require.Len(t, widths, 2)
+		assert.Equal(t, 6, widths[0], "fixed column stays at natural width")
+		assert.Equal(t, 52, widths[1], "flex column absorbs remaining space (60-2sep-6)")
+	})
+
+	t.Run("flex column expands beyond MaxWidth", func(t *testing.T) {
+		columns := []string{"id", "description"}
+		rows := [][]string{
+			{"1", "short"},
+		}
+		hints := []ColumnHint{
+			{},                         // id - fixed
+			{Flex: true, MaxWidth: 30}, // description - flex
+		}
+
+		// Natural: id=2, description=11("description" header)
+		// MaxWidth caps initial size to 30, but flex expands beyond that.
+		// Give 100 chars → flex gets 100 - 2sep - 2 = 96.
+		widths := calculateColumnWidths(columns, rows, 100, hints)
+		require.Len(t, widths, 2)
+		assert.Equal(t, 2, widths[0], "fixed column stays at natural width")
+		assert.Equal(t, 96, widths[1], "flex column expands beyond MaxWidth to fill space")
+	})
+
+	t.Run("multiple flex columns split surplus", func(t *testing.T) {
+		columns := []string{"a", "b", "c"}
+		rows := [][]string{{"x", "y", "z"}}
+		hints := []ColumnHint{
+			{},           // a - fixed
+			{Flex: true}, // b - flex
+			{Flex: true}, // c - flex
+		}
+
+		// Natural: a=1, b=1, c=1, seps=4 → 7 total. Give 27 → 20 surplus
+		// split between b and c.
+		widths := calculateColumnWidths(columns, rows, 27, hints)
+		require.Len(t, widths, 3)
+		assert.Equal(t, 1, widths[0], "fixed column unchanged")
+		total := widths[1] + widths[2]
+		assert.Equal(t, 22, total, "flex columns absorb all surplus")
+	})
+
+	t.Run("no flex no expansion", func(t *testing.T) {
+		columns := []string{"name", "age"}
+		rows := [][]string{{"Alice", "30"}}
+		hints := []ColumnHint{
+			{Priority: 5},
+			{Priority: 5},
+		}
+
+		// Natural: name=5("Alice"), age=3("age"), seps=2 → 10 total.
+		// Give 100 chars → no expansion since no flex columns.
+		widths := calculateColumnWidths(columns, rows, 100, hints)
+		require.Len(t, widths, 2)
+		assert.Equal(t, 5, widths[0], "non-flex stays at natural width")
+		assert.Equal(t, 3, widths[1], "non-flex stays at natural width")
+	})
+}
+
+func TestHasFlexColumn(t *testing.T) {
+	t.Run("no hints", func(t *testing.T) {
+		assert.False(t, HasFlexColumn(nil))
+	})
+
+	t.Run("no flex", func(t *testing.T) {
+		hints := map[string]ColumnHint{
+			"a": {MaxWidth: 10},
+			"b": {Priority: 5},
+		}
+		assert.False(t, HasFlexColumn(hints))
+	})
+
+	t.Run("has flex", func(t *testing.T) {
+		hints := map[string]ColumnHint{
+			"a": {MaxWidth: 10},
+			"b": {Flex: true},
+		}
+		assert.True(t, HasFlexColumn(hints))
+	})
+
+	t.Run("hidden flex column ignored", func(t *testing.T) {
+		hints := map[string]ColumnHint{
+			"a": {MaxWidth: 10},
+			"b": {Flex: true, Hidden: true},
+		}
+		assert.False(t, HasFlexColumn(hints), "hidden flex column should be ignored")
+	})
+}
+
+func TestColumnarOverhead(t *testing.T) {
+	t.Run("single column no row numbers", func(t *testing.T) {
+		// Just borders: 2
+		assert.Equal(t, 2, ColumnarOverhead(1, false, 0))
+	})
+
+	t.Run("three columns no row numbers", func(t *testing.T) {
+		// 2 borders + 2 separators * 2 = 6
+		assert.Equal(t, 6, ColumnarOverhead(3, false, 0))
+	})
+
+	t.Run("two columns with row numbers", func(t *testing.T) {
+		// 2 borders + 1 sep between cols + rowNumWidth(3 for "10"+2pad=4) + 1 sep for rowNum
+		// = 2 + 2 + 4 + 2 = 10
+		assert.Equal(t, 10, ColumnarOverhead(2, true, 10))
+	})
+}
+
+func TestShrinkProportional(t *testing.T) {
+	t.Run("narrow columns preserved while wide columns shrink", func(t *testing.T) {
+		// 3 narrow (7 each) + 1 wide (40). Total = 61. usableWidth = 40.
+		// Narrow columns should stay near natural size; wide column absorbs shrink.
+		widths := shrinkProportional([]int{7, 7, 7, 40}, 40)
+		total := totalUsed(widths)
+		assert.Equal(t, 40, total, "total must equal usableWidth")
+
+		// Narrow columns should keep their natural width (7) since they fit
+		// within a fair share of 10.
+		for i := 0; i < 3; i++ {
+			assert.Equal(t, 7, widths[i], "narrow column %d should be preserved", i)
+		}
+		// Wide column gets the remainder
+		assert.Equal(t, 19, widths[3], "wide column absorbs the shrink")
+	})
+
+	t.Run("lock guard prevents starvation of wide column", func(t *testing.T) {
+		// Regression test: [7,7,7,40] at usableWidth=28.
+		// Without the guard, locking [7,7,7] leaves only 7 for the wide column
+		// (below minReadableWidth=8). The guard should detect this and fall back
+		// to proportional shrink across all columns.
+		widths := shrinkProportional([]int{7, 7, 7, 40}, 28)
+		total := totalUsed(widths)
+		assert.Equal(t, 28, total, "total must equal usableWidth")
+		assert.GreaterOrEqual(t, widths[3], minReadableWidth,
+			"wide column must stay above minReadableWidth after lock guard")
+	})
+
+	t.Run("all columns fit within usableWidth", func(t *testing.T) {
+		widths := shrinkProportional([]int{5, 5, 5}, 30)
+		assert.Equal(t, []int{5, 5, 5}, widths, "no shrinking needed")
+	})
+
+	t.Run("defaultMaxColWidth caps excessive widths", func(t *testing.T) {
+		widths := shrinkProportional([]int{100, 10}, 60)
+		total := totalUsed(widths)
+		assert.Equal(t, 50, total, "total should equal usableWidth after cap+shrink")
+		assert.LessOrEqual(t, widths[0], defaultMaxColWidth,
+			"wide column should be capped at defaultMaxColWidth initially")
+	})
 }
 
 func TestShrinkByPriority(t *testing.T) {
@@ -290,6 +453,79 @@ func TestIsColumnarReadable(t *testing.T) {
 		assert.False(t, IsColumnarReadable(columns, rows, 45, nil, IsColumnarReadableOpts{RowNumberStyle: "numbered"}))
 		// With ample width, always readable
 		assert.True(t, IsColumnarReadable(columns, rows, 70, nil, IsColumnarReadableOpts{RowNumberStyle: "numbered"}))
+	})
+
+	t.Run("MaxWidth hint below minReadable does not flag column as unreadable", func(t *testing.T) {
+		// A column with a long header name ("severity"=8) but MaxWidth=5 (from
+		// an enum like ["error","warn","info"]) should not be treated as unreadable.
+		// The MaxWidth cap means the column is designed to be narrow.
+		columns := []string{"severity", "message"}
+		rows := [][]string{
+			{"error", "something went wrong"},
+			{"warn", "check this out"},
+		}
+		hints := map[string]ColumnHint{
+			"severity": {MaxWidth: 5, Priority: 10},
+			"message":  {Priority: 15},
+		}
+		// At 60 chars both columns fit; severity gets capped to 5 which is fine
+		assert.True(t, IsColumnarReadable(columns, rows, 60, hints, IsColumnarReadableOpts{}))
+	})
+
+	t.Run("flex column never triggers unreadable", func(t *testing.T) {
+		// A flex column with very wide data should not cause list fallback.
+		// Flex columns accept whatever width they get by design.
+		columns := []string{"severity", "message"}
+		rows := [][]string{
+			{"error", "validating https://scafctl.dev/api/v1/clusters/prod-east-1/nodes/worker-07 against schema version 2.4.1"},
+			{"warn", "certificate expiry approaching for endpoint https://scafctl.dev/api/v1/auth/tokens/refresh"},
+		}
+		hints := map[string]ColumnHint{
+			"severity": {MaxWidth: 8, Priority: 10},
+			"message":  {Flex: true, Priority: 5},
+		}
+		// At 80 chars, the 128-char message would normally be unreadable,
+		// but since it's Flex, the table should still be considered readable.
+		assert.True(t, IsColumnarReadable(columns, rows, 80, hints, IsColumnarReadableOpts{}))
+		// Also works at wider widths
+		assert.True(t, IsColumnarReadable(columns, rows, 120, hints, IsColumnarReadableOpts{}))
+		assert.True(t, IsColumnarReadable(columns, rows, 160, hints, IsColumnarReadableOpts{}))
+	})
+
+	t.Run("flex column with MaxWidth never triggers unreadable", func(t *testing.T) {
+		columns := []string{"severity", "message"}
+		rows := [][]string{
+			{"error", "validating https://scafctl.dev/api/v1/clusters/prod-east-1"},
+		}
+		hints := map[string]ColumnHint{
+			"severity": {MaxWidth: 8, Priority: 10},
+			"message":  {Flex: true, MaxWidth: 60, Priority: 5},
+		}
+		assert.True(t, IsColumnarReadable(columns, rows, 80, hints, IsColumnarReadableOpts{}))
+	})
+
+	t.Run("flex-only no MaxWidth does not squeeze fixed columns", func(t *testing.T) {
+		// Simulates schema-parsed columns where unbounded strings get
+		// Flex: true with no MaxWidth. The flex column's wide content
+		// must not inflate totalNeeded and squeeze fixed columns below
+		// minReadableWidth.
+		columns := []string{"name", "status", "description"}
+		rows := [][]string{
+			{"prod-east-1", "healthy", "primary production cluster serving east-coast traffic with 47 worker nodes across 3 availability zones"},
+			{"staging-west", "degraded", "staging environment for west-coast deployment pipeline validation and integration testing"},
+		}
+		hints := map[string]ColumnHint{
+			"name":        {Priority: 20},
+			"status":      {Priority: 15, MaxWidth: 10},
+			"description": {Flex: true, Priority: 5},
+		}
+		// At 80 chars, fixed columns (name=12, status=10) fit easily.
+		// The 115-char description is flex and should not cause fallback.
+		assert.True(t, IsColumnarReadable(columns, rows, 80, hints, IsColumnarReadableOpts{}),
+			"flex-only column with wide content should not trigger list fallback")
+		// Even at narrow widths, flex absorbs the squeeze
+		assert.True(t, IsColumnarReadable(columns, rows, 50, hints, IsColumnarReadableOpts{}),
+			"flex-only column should keep table readable at narrow width")
 	})
 }
 

--- a/pkg/tui/panel.go
+++ b/pkg/tui/panel.go
@@ -495,7 +495,7 @@ func renderColumnarTable(node any, opts TableOptions, termWidth int) string {
 		}
 		naturalContentWidth := formatter.CalculateNaturalColumnarWidthWithHints(columns, rows, showRowNum, len(rows), fmtHintsForWidth, allHidden)
 		naturalTableWidth := naturalContentWidth + 2 // +2 for side borders
-		if naturalTableWidth < termWidth {
+		if naturalTableWidth < termWidth && !HasFlexColumn(opts.ColumnHints) {
 			tableWidth = naturalTableWidth
 		}
 
@@ -546,6 +546,8 @@ func renderColumnarTable(node any, opts TableOptions, termWidth int) string {
 				Priority:    h.Priority,
 				Align:       h.Align,
 				DisplayName: h.DisplayName,
+				Hidden:      h.Hidden,
+				Flex:        h.Flex,
 			}
 		}
 	}

--- a/pkg/tui/schema.go
+++ b/pkg/tui/schema.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+
+	"charm.land/lipgloss/v2"
 )
 
 // ColumnHint provides display hints for a specific column in columnar table rendering.
@@ -36,6 +38,27 @@ type ColumnHint struct {
 	// Derived from JSON Schema deprecated: true.
 	// Merges with the existing HiddenColumns mechanism.
 	Hidden bool
+
+	// Flex marks this column as a flex column that absorbs remaining
+	// terminal width after fixed columns are allocated. When set, bordered
+	// tables fill the full terminal width instead of shrinking to content.
+	// MaxWidth acts as a minimum guarantee during initial sizing, not a
+	// cap on expansion.
+	// Derived from JSON Schema when a property has no maxLength, enum,
+	// or format constraint (i.e. MaxWidth == 0). Can also be set manually.
+	Flex bool
+}
+
+// HasFlexColumn reports whether any visible (non-hidden) hint has Flex set.
+// Hidden columns are excluded because they are never rendered and should not
+// influence table width decisions.
+func HasFlexColumn(hints map[string]ColumnHint) bool {
+	for _, h := range hints {
+		if h.Flex && !h.Hidden {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseSchema extracts [ColumnHint] values from a standard JSON Schema document.
@@ -134,8 +157,8 @@ func parseSchemaObject(raw map[string]any) (map[string]ColumnHint, error) { //no
 			maxEnum := 0
 			for _, v := range enumVals {
 				s := fmt.Sprintf("%v", v)
-				if len(s) > maxEnum {
-					maxEnum = len(s)
+				if w := lipgloss.Width(s); w > maxEnum {
+					maxEnum = w
 				}
 			}
 			if maxEnum > 0 && (hint.MaxWidth == 0 || maxEnum < hint.MaxWidth) {
@@ -161,6 +184,19 @@ func parseSchemaObject(raw map[string]any) (map[string]ColumnHint, error) { //no
 			hint.Hidden = true
 		}
 
+		// Ensure MaxWidth is at least as wide as the display header so the
+		// column title is not truncated by a width cap derived from data
+		// (e.g. enum values shorter than the header text).
+		if hint.MaxWidth > 0 {
+			header := key
+			if hint.DisplayName != "" {
+				header = hint.DisplayName
+			}
+			if hw := lipgloss.Width(header); hw > hint.MaxWidth {
+				hint.MaxWidth = hw
+			}
+		}
+
 		// Priority: required fields get a boost of +10,
 		// then ordered by declaration (first property = highest base priority).
 		basePriority := numProps - i // first property gets highest base
@@ -168,6 +204,15 @@ func parseSchemaObject(raw map[string]any) (map[string]ColumnHint, error) { //no
 			basePriority += 10
 		}
 		hint.Priority = basePriority
+
+		// Columns without a MaxWidth constraint (no maxLength, enum, or
+		// format cap) are natural flex candidates — they have unbounded
+		// content that should absorb remaining terminal width.
+		// Hidden columns are excluded — they are never rendered and should
+		// not influence table width decisions.
+		if hint.MaxWidth == 0 && !hint.Hidden {
+			hint.Flex = true
+		}
 
 		hints[key] = hint
 	}

--- a/pkg/tui/schema_test.go
+++ b/pkg/tui/schema_test.go
@@ -142,8 +142,9 @@ func TestParseSchema_ArrayItems(t *testing.T) {
 	assert.Equal(t, 20, hints["label"].MaxWidth)
 }
 
-func TestParseSchema_MaxLengthOverridesEnum(t *testing.T) {
-	// When both maxLength and enum are present, maxLength takes precedence
+func TestParseSchema_MaxLengthWithHeaderFloor(t *testing.T) {
+	// When both maxLength and enum are present, maxLength takes precedence.
+	// The result is then floored at the header width to prevent truncation.
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -158,6 +159,98 @@ func TestParseSchema_MaxLengthOverridesEnum(t *testing.T) {
 	hints, err := ParseSchema([]byte(schema))
 	require.NoError(t, err)
 
-	// maxLength=5 should win over enum longest ("inactive"=8)
-	assert.Equal(t, 5, hints["status"].MaxWidth)
+	// maxLength=5 would win over enum ("inactive"=8), but header
+	// "status" (6 chars) is wider, so MaxWidth floors at 6.
+	assert.Equal(t, 6, hints["status"].MaxWidth)
+}
+
+func TestParseSchema_MaxWidthFloorsAtHeaderWidth(t *testing.T) {
+	// When enum-derived MaxWidth is narrower than the header (title or key),
+	// MaxWidth should be bumped to the header width so the header is not truncated.
+	schema := `{
+		"type": "object",
+		"properties": {
+			"severity": {
+				"type": "string",
+				"title": "Severity",
+				"enum": ["error", "warn", "info"]
+			},
+			"short": {
+				"type": "string",
+				"title": "S",
+				"enum": ["longvalue"]
+			}
+		}
+	}`
+
+	hints, err := ParseSchema([]byte(schema))
+	require.NoError(t, err)
+
+	// "Severity" (8 chars) > max enum "error" (5 chars) → MaxWidth = 8
+	assert.Equal(t, 8, hints["severity"].MaxWidth)
+	// "S" (1 char) < max enum "longvalue" (9 chars) → MaxWidth stays 9
+	assert.Equal(t, 9, hints["short"].MaxWidth)
+}
+
+func TestParseSchema_FlexAutoSet(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"severity": {
+				"type": "string",
+				"enum": ["error", "warn", "info"]
+			},
+			"message": {
+				"type": "string"
+			},
+			"count": {
+				"type": "integer"
+			},
+			"timestamp": {
+				"type": "string",
+				"format": "date-time"
+			}
+		}
+	}`
+
+	hints, err := ParseSchema([]byte(schema))
+	require.NoError(t, err)
+
+	// severity has enum → MaxWidth set → not flex
+	assert.False(t, hints["severity"].Flex, "enum column should not be flex")
+	assert.Greater(t, hints["severity"].MaxWidth, 0)
+
+	// message has no maxLength/enum/format → MaxWidth=0 → flex
+	assert.True(t, hints["message"].Flex, "unconstrained string column should be flex")
+	assert.Equal(t, 0, hints["message"].MaxWidth)
+
+	// count is integer with no constraints → MaxWidth=0 → flex
+	assert.True(t, hints["count"].Flex, "unconstrained integer column should be flex")
+
+	// timestamp has format → MaxWidth set → not flex
+	assert.False(t, hints["timestamp"].Flex, "format-constrained column should not be flex")
+	assert.Greater(t, hints["timestamp"].MaxWidth, 0)
+}
+
+func TestParseSchema_HiddenColumnNotFlex(t *testing.T) {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": { "type": "string" },
+			"internal_code": {
+				"type": "string",
+				"deprecated": true
+			}
+		}
+	}`
+
+	hints, err := ParseSchema([]byte(schema))
+	require.NoError(t, err)
+
+	// name: no constraints, not hidden → flex
+	assert.True(t, hints["name"].Flex, "visible unconstrained column should be flex")
+
+	// internal_code: deprecated (hidden), no constraints → should NOT be flex
+	assert.True(t, hints["internal_code"].Hidden, "deprecated column should be hidden")
+	assert.False(t, hints["internal_code"].Flex, "hidden column should not be flex")
 }


### PR DESCRIPTION
check and proportional shrink

- Fix IsColumnarReadable to account for MaxWidth hint caps when checking if a column was shrunk below minReadableWidth; columns designed to be narrow (e.g. schema enums) no longer trigger false "unreadable" detection
- Replace inline proportional shrink with shrinkProportional() that locks naturally-small columns at their full width and only shrinks wider columns, preventing short columns like "severity" from being truncated to "sev..." while longer columns have unused padding
- Add test for MaxWidth hint readability check

