### PR TITLE
feat: add schema-aware detail view rendering and per-instance expression provider

### DIFF
--- a/.github/agents/commit-message.agent.md
+++ b/.github/agents/commit-message.agent.md
@@ -12,9 +12,11 @@ You are a commit message generator for the **kvx** project. You analyze changes 
 1. Run `git diff --cached --stat` to see staged changes (or `git diff --stat` if nothing staged)
 2. Run `git diff --cached` (or `git diff`) to read the actual changes
 3. **Only reference files that are actually staged or committed** -- do not mention files that are gitignored or untracked, even if they exist on disk
-4. Generate a commit message following the format below
-5. Output the message in a code block for the user to copy
-6. **DO NOT** run `git commit` -- the user will commit manually
+4. Run `gh issue list --state open --limit 50 --json number,title` to find open issues
+5. Match issues to changes in the diff -- include `Closes #NNN` for each resolved issue
+6. Generate a commit message following the format below
+7. Output the message in a code block for the user to copy
+8. **DO NOT** run `git commit` -- the user will commit manually
 
 **IMPORTANT**: Base the commit message solely on what `git diff --cached --stat` reports. If a file doesn't appear in the diff, it is not part of the commit and must not be mentioned in the message.
 
@@ -24,22 +26,28 @@ You are a commit message generator for the **kvx** project. You analyze changes 
 <type>(<scope>): <description>
 
 <body>
+
+<issue references>
 ```
 
 The **description** (first line) appears in the changelog and release notes. Keep it focused and meaningful.
 
 The **body** summarizes what was actually done -- list the key changes as bullet points. Include a body for any commit that touches multiple files or areas. Only skip the body for truly trivial single-file changes.
 
+The **issue references** section lists one `Closes #NNN` per line for each GitHub issue resolved by the changes. Only include issues whose requirements are fully met by the diff.
+
 ### Example
 
 ```
-chore: add AI agents, prompts, skills, and copilot instructions
+feat(tui): add theme selection menu
 
-Add Copilot customization files adapted from abaker9-ai:
-- 5 agents: commit-message, go-build-resolver, go-reviewer, issue-creator, planner
-- 6 prompts: /commit, /go-build, /go-review, /go-test, /issue, /plan
-- 2 skills: golang-patterns, golang-testing
-- Updated copilot-instructions.md with golang-testing skill reference
+Add interactive theme picker accessible via the TUI menu:
+- New theme selection view in internal/ui/
+- Support for all built-in themes (midnight, dark, warm, cool)
+- Preview panel showing theme colors before applying
+- Persist selection to config file
+
+Closes #42
 ```
 
 ### Types (from cliff.toml changelog groups)
@@ -126,7 +134,18 @@ Add `!` after scope and a `BREAKING CHANGE:` footer:
 feat(resolver)!: change resolver output format
 
 BREAKING CHANGE: resolver outputs are now wrapped in a metadata envelope
+
+Closes #123
 ```
+
+## Issue Matching
+
+When matching issues to changes:
+
+1. Read the issue title and compare against the diff
+2. Only claim `Closes` if the diff **fully** implements the issue
+3. If an issue is partially addressed, use `Relates to #NNN` instead
+4. If no issues match, omit the references section
 
 ## Amending Commits
 
@@ -175,6 +194,8 @@ Add interactive theme picker accessible via the TUI menu:
 - Support for all built-in themes (midnight, dark, warm, cool)
 - Preview panel showing theme colors before applying
 - Persist selection to config file
+
+Closes #42
 ```
 
 For amends, also provide the full command:
@@ -186,5 +207,7 @@ Add interactive theme picker accessible via the TUI menu:
 - New theme selection view in internal/ui/
 - Support for all built-in themes (midnight, dark, warm, cool)
 - Preview panel showing theme colors before applying
-- Persist selection to config file"
+- Persist selection to config file
+
+Closes #42"
 ```

--- a/.github/agents/go-fixer.agent.md
+++ b/.github/agents/go-fixer.agent.md
@@ -1,0 +1,161 @@
+---
+description: "Go code fixer for kvx. Fixes build errors, review findings, PR comments, and test failures. Applies minimal surgical changes, verifies with build/vet/lint, adds test coverage, and optionally responds to PR review threads. Use after a review, when builds fail, or when tests need fixing."
+name: "go-fixer"
+tools: [read, edit, search, execute, todo]
+handoffs:
+  - label: "Generate commit message"
+    prompt: "Generate a commit message for the fixes just applied."
+    agent: "commit-message"
+  - label: "Re-run review"
+    prompt: "Re-run the code review to check for any remaining issues."
+    agent: "go-reviewer"
+---
+You are an expert Go code fixer for the **kvx** project. You fix code issues from any source -- build errors, code review findings, PR review comments, or test failures -- with **minimal, surgical changes**.
+
+## Project Context
+
+- kvx is a terminal-based UI for exploring structured data (JSON, YAML, TOML, NDJSON, CSV)
+- Build: `go build -ldflags "-s -w -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X main.BuildVersion=dev -X main.Commit=$(git rev-parse HEAD)" -o dist/kvx .`
+- Lint: `golangci-lint run`
+- Test: `go test ./...`
+- Business logic lives in `pkg/` and `internal/`, CLI wiring in `cmd/`
+
+## Workflow
+
+### Phase 1: Identify Issues
+
+Read the conversation context to find what needs fixing. Sources include:
+- Build/vet/lint errors (run `go build ./...`, `go vet ./...`, `golangci-lint run` if not already done)
+- Code review findings (from go-reviewer)
+- PR review comments with thread IDs (from pr-reviewer)
+- Test failures
+
+### Phase 2: Apply Fixes
+
+For each issue:
+1. Read the file and understand the surrounding context
+2. Apply the minimal fix -- don't refactor beyond what's needed
+3. Follow all kvx conventions (functional options, bubbletea patterns, lipgloss styling, business logic in `pkg/`/`internal/`)
+
+### Phase 3: Verify
+
+After all fixes are applied, run in this order:
+
+1. `go build ./...` -- must compile
+2. `go vet ./...` -- no warnings
+3. `golangci-lint run` -- no lint issues
+4. `go test ./...` -- all tests pass
+
+Fix any errors introduced by the changes before proceeding.
+
+### Phase 4: Coverage Check
+
+Run coverage on changed packages:
+```bash
+go test -coverprofile=cover/patch.out ./pkg/changed/... ./internal/changed/...
+```
+
+If any changed file has patch coverage below 60%, add tests to cover the new/modified lines.
+
+### Phase 5: Respond to PR Threads (if applicable)
+
+If the issues came from PR review threads (thread IDs are in the conversation), respond to and resolve each thread.
+
+**After responding to all known threads**, sweep for any remaining unresolved threads:
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            comments(first: 20) {
+              nodes {
+                id
+                body
+                author { login }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner=oakwood-commons -f repo=kvx -F pr=<PR_NUMBER>
+```
+Reply to and resolve any stragglers. The PR should have **zero unresolved threads** when done.
+
+**Reply to a thread:**
+```bash
+gh api graphql -f query='
+  mutation($id: ID!, $body: String!) {
+    addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $id, body: $body}) {
+      comment { id }
+    }
+  }' -f id=<THREAD_ID> -f body="<response>"
+```
+
+**Resolve a thread:**
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId=<THREAD_ID>
+```
+
+Response templates:
+- **Fixed**: "Fixed in `<brief description>`. Thanks!"
+- **Question answered**: "<answer>"
+- **Nit accepted**: "Good catch, fixed."
+- **Disagree**: "<reasoning>. Happy to discuss further." (resolve the thread)
+- **Outdated**: "This was addressed in a subsequent change -- the code now does X."
+
+If no PR thread IDs are present, skip this phase.
+
+## Common Fix Patterns
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `undefined: X` | Missing import, typo, unexported | Add import or fix casing |
+| `cannot use X as type Y` | Type mismatch, pointer/value | Type conversion or dereference |
+| `X does not implement Y` | Missing method | Implement method with correct receiver |
+| `import cycle not allowed` | Circular dependency | Extract shared types to new package |
+| `cannot find package` | Missing dependency | `go get pkg@version` or `go mod tidy` |
+| `missing return` | Incomplete control flow | Add return statement |
+| `declared but not used` | Unused var/import | Remove or use blank identifier |
+
+## Hard Constraints
+
+- **Surgical fixes only** -- don't refactor beyond what's needed
+- **NEVER** run `git commit` or `git push` -- only make code changes
+- **NEVER** add `//nolint` without explicit approval
+- **NEVER** change function signatures unless necessary
+- **ALWAYS** verify with build/vet/lint before declaring done
+- **ALWAYS** resolve all PR threads after responding -- including disagreements
+- Every new or changed file must have tests -- target 70%+ patch coverage
+- Only run `go mod tidy -v` **after** fixing module/dependency changes
+
+## Stop Conditions
+
+Stop and report if:
+- Same error persists after 3 fix attempts
+- Fix introduces more errors than it resolves
+- Error requires architectural changes beyond scope
+
+## Output Format
+
+```
+[FIXED] internal/navigator/navigator.go:42
+  Error: undefined: SomeType
+  Fix: Added import "github.com/oakwood-commons/kvx/internal/formatter"
+  Remaining errors: 3
+```
+
+Final: `Build Status: SUCCESS/FAILED | Errors Fixed: N | Files Modified: list`

--- a/.github/hooks/git-safety.json
+++ b/.github/hooks/git-safety.json
@@ -3,7 +3,20 @@
     "PreToolUse": [
       {
         "type": "command",
-        "command": ".github/hooks/scripts/git-safety.sh",
+        "platform": "win32",
+        "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File .github/hooks/scripts/git-safety.ps1",
+        "timeout": 5
+      },
+      {
+        "type": "command",
+        "platform": "darwin",
+        "command": "bash .github/hooks/scripts/git-safety.sh",
+        "timeout": 5
+      },
+      {
+        "type": "command",
+        "platform": "linux",
+        "command": "bash .github/hooks/scripts/git-safety.sh",
         "timeout": 5
       }
     ]

--- a/.github/hooks/go-format.json
+++ b/.github/hooks/go-format.json
@@ -3,7 +3,20 @@
     "PostToolUse": [
       {
         "type": "command",
-        "command": ".github/hooks/scripts/go-format.sh",
+        "platform": "win32",
+        "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File .github/hooks/scripts/go-format.ps1",
+        "timeout": 10
+      },
+      {
+        "type": "command",
+        "platform": "darwin",
+        "command": "bash .github/hooks/scripts/go-format.sh",
+        "timeout": 10
+      },
+      {
+        "type": "command",
+        "platform": "linux",
+        "command": "bash .github/hooks/scripts/go-format.sh",
         "timeout": 10
       }
     ]

--- a/.github/hooks/scripts/git-safety.ps1
+++ b/.github/hooks/scripts/git-safety.ps1
@@ -1,0 +1,27 @@
+# PreToolUse hook: block git commit/push/amend unless user explicitly approves.
+# Reads JSON from stdin, checks if the command is a git write operation.
+
+$ErrorActionPreference = 'Stop'
+
+$hookInput = [System.Console]::In.ReadToEnd()
+
+# Extract the command being run
+if ($hookInput -match '"command"\s*:\s*"([^"]*)"') {
+    $cmd = $Matches[1]
+} else {
+    exit 0
+}
+
+# Check for git write operations
+if ($cmd -match 'git\s+(commit|push|amend|reset\s+--hard|rebase|force-push)') {
+    @'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Git write operation detected. This project requires explicit user approval before committing, pushing, or rewriting history."
+  }
+}
+'@
+    exit 0
+}

--- a/.github/hooks/scripts/go-format.ps1
+++ b/.github/hooks/scripts/go-format.ps1
@@ -1,0 +1,30 @@
+# PostToolUse hook: auto-format .go files after edits
+# Reads JSON from stdin, checks if a .go file was edited, runs goimports.
+
+$ErrorActionPreference = 'Stop'
+
+$hookInput = [System.Console]::In.ReadToEnd()
+
+# Extract the file path from the tool input
+if ($hookInput -match '"filePath"\s*:\s*"([^"]*)"') {
+    $file = $Matches[1]
+} else {
+    exit 0
+}
+
+# Only proceed for .go files
+if (-not $file.EndsWith('.go')) {
+    exit 0
+}
+
+# Only format if the file exists
+if (-not (Test-Path $file)) {
+    exit 0
+}
+
+# Run goimports if available, fall back to gofmt
+if (Get-Command goimports -ErrorAction SilentlyContinue) {
+    & goimports -w $file
+} elseif (Get-Command gofmt -ErrorAction SilentlyContinue) {
+    & gofmt -w $file
+}

--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -1,0 +1,54 @@
+---
+description: "Integration and acceptance test conventions for kvx. Defines test scope boundaries across CLI, TUI, renderer, loader, and CEL layers. Use when writing integration or end-to-end tests."
+applyTo: "tests/**,**/*_integration_test.go"
+---
+
+# Integration Test Conventions
+
+## Test Scope Boundaries
+
+Each layer has its own test scope. Do not mix concerns across boundaries.
+
+| Layer | Package | Tests cover | Do NOT test here |
+|-------|---------|-------------|-----------------|
+| CLI commands | `cmd/` | Flag parsing, cobra wiring, output format selection | Business logic, data loading |
+| TUI | `pkg/tui/` | Panel layout, navigation, key handling, interactive rendering | Data parsing, CEL evaluation |
+| Core engine | `pkg/core/` | Data pipeline, option wiring, engine lifecycle | CLI flags, terminal rendering |
+| Formatter | `internal/formatter/` | Table rendering, CSV output, column hints | Navigation, data loading |
+| Navigator | `internal/navigator/` | Cursor movement, breadcrumbs, drill-down/up | Rendering, CLI flags |
+| CEL | `internal/cel/` | Expression evaluation, filtering, where clauses | Data loading, output formatting |
+| Loader | `pkg/loader/` | File parsing (JSON, YAML, TOML, CSV, NDJSON, JWT) | CEL expressions, rendering |
+
+## Snapshot Tests
+
+Snapshot tests live in `tests/snapshots/`. Use `--snapshot` mode to capture TUI output:
+
+```bash
+go run . tests/sample.yaml --snapshot --press "<Right><Right>"
+```
+
+- Update snapshots with `scripts/update_snapshots.sh`
+- Never hand-edit snapshot files
+
+## CLI Integration Tests
+
+CLI tests verify that flags, arguments, and output formats work end-to-end:
+
+```go
+func TestCLI_TableOutput(t *testing.T) {
+    // Run kvx as a subprocess or call root command directly
+    // Assert on stdout content and exit code
+}
+```
+
+- Use `tests/*.yaml`, `tests/*.json` etc. as test fixtures
+- Test both interactive (`--snapshot`) and non-interactive output
+- Test expression evaluation (`-e "_.field"`) end-to-end
+
+## Rules
+
+- Every new CLI command or flag must have a CLI-level test
+- Every new TUI feature (key binding, panel, mode) must have a TUI-level test
+- Snapshot tests are the source of truth for visual output correctness
+- Use `t.Parallel()` for independent test cases
+- Use `-short` flag to skip slow integration tests in unit test runs

--- a/.github/instructions/tui-conventions.instructions.md
+++ b/.github/instructions/tui-conventions.instructions.md
@@ -1,0 +1,117 @@
+---
+description: "TUI conventions for kvx: bubbletea model patterns, lipgloss styling, navigator usage, terminal state management, and interactive mode best practices. Use when writing or editing TUI code."
+applyTo: "pkg/tui/**/*.go,internal/navigator/**/*.go,internal/ui/**/*.go"
+---
+
+# TUI Conventions
+
+## Testing TUI Changes
+
+Interactive UI is hard to test. **Always verify TUI changes with snapshot tests** before considering them done.
+
+### Snapshot Testing
+
+Snapshot tests capture the rendered TUI output and compare it against a known-good baseline in `tests/snapshots/`. This is the primary verification method for visual correctness.
+
+```bash
+# Run kvx in snapshot mode (renders TUI and exits)
+go run . tests/sample.yaml --snapshot --no-color --width 80 --height 30
+
+# With key presses to test a specific state
+go run . tests/sample.yaml --snapshot --no-color --width 80 --height 30 --press "<F1>"
+```
+
+- Snapshot baselines live in `tests/snapshots/` (e.g., `default-80x30.txt`, `f1-80x30.txt`)
+- Update all snapshots: `scripts/update_snapshots.sh`
+- Use `--no-color` and fixed `--width`/`--height` for deterministic output
+- Use `--press "..."` to simulate key sequences and test specific UI states
+- **Never hand-edit snapshot files** -- always regenerate with the script
+- When adding a new TUI feature or key binding, add a corresponding snapshot test
+
+### When to Add Snapshots
+
+- New panel or layout change
+- New key binding that alters the display
+- Changes to table rendering, borders, or styling
+- Changes to status bar, breadcrumbs, or help overlay
+
+### Verification Workflow
+
+After any TUI change:
+1. Run existing snapshot comparisons to check for regressions
+2. Visually inspect with `--snapshot --press "..."` for the affected states
+3. Update baselines if the change is intentional: `scripts/update_snapshots.sh`
+4. Commit updated snapshot files alongside the code change
+
+## Bubbletea Model Pattern
+
+All TUI components follow the bubbletea `Model` interface:
+
+```go
+type Model struct {
+    // immutable config (set at construction)
+    // mutable state (updated in Update)
+}
+
+func (m Model) Init() tea.Cmd    { /* initial commands */ }
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { /* handle messages */ }
+func (m Model) View() string     { /* render to string */ }
+```
+
+### Rules
+
+- `Update` must return a new model value (copy-on-write) -- never mutate and return the same pointer
+  - **Note**: the existing `internal/ui.Model` uses pointer receivers and mutates in place for historical reasons. This rule applies to **new** bubbletea components; do not refactor the existing Model to match
+- `Update` must always return a `tea.Cmd` (use `nil` only when no command is needed)
+- `View` must be pure -- no side effects, no state mutation
+- Use `tea.Batch()` to combine multiple commands
+- Use custom `tea.Msg` types for component communication
+
+## Lipgloss Styling
+
+- Use lipgloss for ALL terminal styling -- never raw ANSI escape codes
+- Define styles as package-level variables or in a theme struct
+- Account for border and padding widths when setting `Width()` or `MaxWidth()`:
+
+```go
+// WRONG: content will be clipped by border width
+style := lipgloss.NewStyle().Width(80).Border(lipgloss.RoundedBorder())
+
+// RIGHT: subtract border width from content width
+borderWidth := 2 // left + right
+style := lipgloss.NewStyle().Width(80 - borderWidth).Border(lipgloss.RoundedBorder())
+```
+
+- Use `lipgloss.Place()` for alignment, not manual padding
+
+## Navigator State
+
+The navigator tracks cursor position and drill-down state for data exploration.
+
+### Rules
+
+- All navigator state mutations go through bubbletea's `Update` message loop -- never mutate from goroutines
+- Cursor position must stay in bounds after data changes (filter, drill-down, drill-up)
+- Breadcrumb path must stay in sync with the current data view
+- Use functional options (`navigator.WithXxx()`) for navigator configuration
+
+## Terminal State Cleanup
+
+- Always restore terminal state on exit (bubbletea handles this, but custom code must not bypass it)
+- `defer cancel()` immediately after context creation, before any early returns
+- Clean up goroutines on quit -- use `context.Context` for cancellation
+- Never leave orphan goroutines after the TUI exits
+
+## Key Bindings
+
+- Define key bindings in a `keyMap` struct implementing `help.KeyMap`
+- Use `key.NewBinding()` with both `key.WithKeys()` and `key.WithHelp()`
+- Group related bindings (navigation, search, mode switching)
+- Document all bindings in the help overlay
+
+## Panels and Layout
+
+- Each panel (data, status, input) is a separate component with its own `View()`
+- Layout composition happens in the top-level model's `View()`
+- Use lipgloss `JoinHorizontal()` / `JoinVertical()` for panel composition
+- Panels must handle zero-width/zero-height gracefully (terminal resize edge case)

--- a/.github/prompts/commit.prompt.md
+++ b/.github/prompts/commit.prompt.md
@@ -6,9 +6,11 @@ Analyze the current changes and generate a conventional commit message. **Output
 
 1. Check `git diff --cached --stat` for staged changes (fall back to `git diff --stat`)
 2. Read the actual diff to understand what changed
-3. If asked to amend, check `git log -1` for the last commit
-4. Generate a message: `<type>(<scope>): <description>` + body with bullet points summarizing key changes
-5. Output in a code block for the user to copy
+3. Run `gh issue list --state open --limit 50 --json number,title` to find open issues
+4. Match issues to changes -- include `Closes #NNN` for resolved issues
+5. If asked to amend, check `git log -1` for the last commit
+6. Generate a message: `<type>(<scope>): <description>` + body with bullet points + issue references
+7. Output in a code block for the user to copy
 
 Always include a body unless the change is a single trivial file edit.
 Types: feat, fix, docs, perf, refactor, style, test, chore, ci, revert

--- a/.github/prompts/startup-check.prompt.md
+++ b/.github/prompts/startup-check.prompt.md
@@ -1,0 +1,31 @@
+---
+description: "kvx: Verify development environment is ready -- check build, tools, and dependencies."
+mode: "agent"
+---
+
+# Startup Check
+
+Verify the kvx development environment is ready.
+
+## Steps
+
+1. Check Go version: `go version`
+2. Build kvx: `go build ./...`
+3. Run vet: `go vet ./...`
+4. Check linter is available: `golangci-lint version`
+5. Check goimports is available: `which goimports || where goimports`
+6. Verify tests pass: `go test ./... -count=1 -short`
+7. Verify kvx runs: `go run . --help`
+
+## Report
+
+Summarize the results as a checklist:
+- [ ] Go version (minimum 1.22)
+- [ ] Build succeeds
+- [ ] Vet passes
+- [ ] golangci-lint available
+- [ ] goimports available
+- [ ] Tests pass
+- [ ] kvx runs
+
+Flag any failures and suggest fixes.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1173,9 +1173,16 @@ func applySnapshotConfigToModel(m *ui.Model, cfg ui.ThemeConfigFile) {
 	}
 }
 
-func printEvalResult(node interface{}, output string, noColor bool, keyColWidth, valueColWidth int, _ int, width int, appName string, path string, yamlOpts formatter.YAMLFormatOptions, tableOpts formatter.TableFormatOptions, treeOpts formatter.TreeOptions, mermaidOpts formatter.MermaidOptions) {
+func printEvalResult(node interface{}, output string, noColor bool, keyColWidth, valueColWidth int, _ int, width int, appName string, path string, yamlOpts formatter.YAMLFormatOptions, tableOpts formatter.TableFormatOptions, treeOpts formatter.TreeOptions, mermaidOpts formatter.MermaidOptions, displaySchema *tui.DisplaySchema) {
 	switch output {
 	case "table":
+		// Schema-aware rendering for single objects with a detail schema.
+		if displaySchema != nil && displaySchema.Detail != nil {
+			if _, ok := node.(map[string]interface{}); ok {
+				fmt.Print(tui.RenderSchemaView(node, displaySchema, width, noColor)) //nolint:forbidigo
+				return
+			}
+		}
 		// For scalar values, print the raw value instead of a table
 		isCollection, isSimpleArray := classifyNode(node)
 
@@ -1220,6 +1227,13 @@ func printEvalResult(node interface{}, output string, noColor bool, keyColWidth,
 			os.Exit(1)
 		}
 	case "auto":
+		// Schema-aware rendering for single objects with a detail schema.
+		if displaySchema != nil && displaySchema.Detail != nil {
+			if _, ok := node.(map[string]interface{}); ok {
+				fmt.Print(tui.RenderSchemaView(node, displaySchema, width, noColor)) //nolint:forbidigo
+				return
+			}
+		}
 		// Auto mode: use table when readable, fall back to list when columns are too narrow
 		isCollection, isSimpleArray := classifyNode(node)
 
@@ -1425,49 +1439,26 @@ func tableFormatOptionsFromConfig(cfg ui.ThemeConfigFile) formatter.TableFormatO
 		}
 	}
 
-	// When a display schema with list config is present and the user has not
-	// set an explicit column order, derive one from the listed fields so that
-	// non-interactive columnar output shows the same prominent columns as the
-	// TUI list view.
-	if parsedDisplaySchema != nil && parsedDisplaySchema.List != nil && len(opts.ColumnOrder) == 0 {
-		lc := parsedDisplaySchema.List
-		seen := map[string]bool{}
-		var order []string
-		addUnique := func(field string) {
-			if field != "" && !seen[field] {
-				seen[field] = true
-				order = append(order, field)
-			}
-		}
-		addUnique(lc.TitleField)
-		for _, f := range lc.BadgeFields {
-			addUnique(f)
-		}
-		for _, f := range lc.SecondaryFields {
-			addUnique(f)
-		}
-		if lc.SubtitleField != "" {
-			addUnique(lc.SubtitleField)
-		}
-		if len(order) > 0 {
+	// Derive column order and hidden columns from the display schema.
+	// This uses the same logic as tui.DeriveTableOptionsFromSchema but
+	// applies to the formatter-level TableFormatOptions used by the CLI.
+	if parsedDisplaySchema != nil {
+		order, hidden := tui.DeriveTableOptionsFromSchema(parsedDisplaySchema)
+		if len(order) > 0 && len(opts.ColumnOrder) == 0 && len(opts.SelectColumns) == 0 {
 			opts.SelectColumns = order
 		}
-	}
-	// When a display schema with detail config lists hidden fields, merge them
-	// into HiddenColumns (user-specified hidden columns take precedence and
-	// are never removed).
-	if parsedDisplaySchema != nil && parsedDisplaySchema.Detail != nil {
-		existingHidden := make(map[string]bool, len(opts.HiddenColumns))
-		for _, c := range opts.HiddenColumns {
-			existingHidden[c] = true
-		}
-		for _, f := range parsedDisplaySchema.Detail.HiddenFields {
-			if !existingHidden[f] {
-				opts.HiddenColumns = append(opts.HiddenColumns, f)
+		if len(hidden) > 0 {
+			existingHidden := make(map[string]bool, len(opts.HiddenColumns))
+			for _, c := range opts.HiddenColumns {
+				existingHidden[c] = true
+			}
+			for _, f := range hidden {
+				if !existingHidden[f] {
+					opts.HiddenColumns = append(opts.HiddenColumns, f)
+				}
 			}
 		}
 	}
-
 	return opts
 }
 
@@ -2758,7 +2749,7 @@ var rootCmd = &cobra.Command{
 				}
 				treeOpts := treeFormatOptionsFromConfig(cfg, outputWidth, stdoutIsPiped())
 				mermaidOpts := mermaidFormatOptionsFromConfig(cfg)
-				printEvalResult(node, output, noColor, keyW, valueW, outputHeight, outputWidth, appName, "_", yamlOpts, tableOpts, treeOpts, mermaidOpts)
+				printEvalResult(node, output, noColor, keyW, valueW, outputHeight, outputWidth, appName, "_", yamlOpts, tableOpts, treeOpts, mermaidOpts, parsedDisplaySchema)
 				if debugLog && len(dc.events) > 0 {
 					printDebugEvents(dc.events)
 				}
@@ -3124,7 +3115,7 @@ var rootCmd = &cobra.Command{
 		}
 		treeOpts := treeFormatOptionsFromConfig(cfg, outputWidth, stdoutIsPiped())
 		mermaidOpts := mermaidFormatOptionsFromConfig(cfg)
-		printEvalResult(node, output, noColor, keyW, valueW, outputHeight, outputWidth, appNameVal, "_", yamlOpts, tableOpts, treeOpts, mermaidOpts)
+		printEvalResult(node, output, noColor, keyW, valueW, outputHeight, outputWidth, appNameVal, "_", yamlOpts, tableOpts, treeOpts, mermaidOpts, parsedDisplaySchema)
 		if debugLog && len(dc.events) > 0 {
 			printDebugEvents(dc.events)
 		}

--- a/internal/ui/detail_view.go
+++ b/internal/ui/detail_view.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -26,6 +27,12 @@ type renderedSection struct {
 	Title  string   // Section heading (may be empty)
 	Lines  []string // Rendered lines
 	Layout string   // Layout type for reference
+}
+
+// BuildDetailView creates a DetailViewModel from an object using the display schema.
+// This is the public entry point for library consumers (pkg/tui).
+func BuildDetailView(node interface{}, schema *DisplaySchema, width, height int) *DetailViewModel {
+	return buildDetailViewModel(node, schema, width, height)
 }
 
 // buildDetailViewModel creates a DetailViewModel from an object using the display schema.
@@ -119,7 +126,7 @@ func renderDetailSection(obj map[string]interface{}, section DetailSection, widt
 	case DisplayLayoutTags:
 		rs.Lines = renderTagsSection(obj, section.Fields, width, hidden)
 	default: // table
-		rs.Lines = renderTableSection(obj, section.Fields, width, hidden)
+		rs.Lines = renderTableSection(obj, section.Fields, width, hidden, section.ColumnOrder)
 	}
 
 	return rs
@@ -235,7 +242,9 @@ func renderTagsSection(obj map[string]interface{}, fields []string, width int, h
 }
 
 // renderTableSection renders fields as KEY/VALUE rows.
-func renderTableSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool) []string {
+// When a field contains []map[string]any, it renders an inline columnar table
+// instead of the placeholder "[N items]" text.
+func renderTableSection(obj map[string]interface{}, fields []string, width int, hidden map[string]bool, columnOrder []string) []string {
 	th := CurrentTheme()
 	keyStyle := lipgloss.NewStyle().Foreground(th.KeyColor)
 	valStyle := lipgloss.NewStyle().Foreground(th.ValueColor)
@@ -263,9 +272,17 @@ func renderTableSection(obj map[string]interface{}, fields []string, width int, 
 		if v == nil {
 			continue
 		}
+
+		// Check if this field is a homogeneous array of maps -> render as inline table.
+		if rows, cols := extractNestedTable(v, columnOrder); rows != nil {
+			tbl := renderInlineColumnarTable(cols, rows, width, &th)
+			lines = append(lines, tbl...)
+			continue
+		}
+
 		key := f
 		if len(key) > maxKeyLen {
-			key = runewidth.Truncate(key, maxKeyLen, "…")
+			key = runewidth.Truncate(key, maxKeyLen, "...")
 		}
 		// Pad key to alignment width
 		key += strings.Repeat(" ", maxKeyLen-runewidth.StringWidth(key))
@@ -388,4 +405,139 @@ func (dv *DetailViewModel) RowCount() (count int, selected int, label string) {
 
 func (dv *DetailViewModel) Update(_ tea.Msg) (CustomView, tea.Cmd) {
 	return dv, nil // detail view has no async messages
+}
+
+// ---------------------------------------------------------------------------
+// Nested table helpers (#62)
+// ---------------------------------------------------------------------------
+
+// extractNestedTable checks whether v is a []map[string]any (homogeneous).
+// If so it returns the rows and an ordered list of column names, applying
+// columnOrder to put preferred columns first.  Returns (nil, nil) otherwise.
+func extractNestedTable(v interface{}, columnOrder []string) ([]map[string]interface{}, []string) {
+	// Accept both []interface{} and []map[string]any (typed slices from Go callers).
+	var arr []interface{}
+	switch typed := v.(type) {
+	case []interface{}:
+		arr = typed
+	case []map[string]any:
+		arr = make([]interface{}, len(typed))
+		for i, m := range typed {
+			arr[i] = m
+		}
+	default:
+		return nil, nil
+	}
+	if len(arr) == 0 {
+		return nil, nil
+	}
+
+	rows := make([]map[string]interface{}, 0, len(arr))
+	colSet := map[string]bool{}
+
+	for _, elem := range arr {
+		m, mOK := elem.(map[string]interface{})
+		if !mOK {
+			return nil, nil // not homogeneous maps
+		}
+		rows = append(rows, m)
+		for k := range m {
+			colSet[k] = true
+		}
+	}
+
+	// Build ordered column list: preferred first, then remaining sorted.
+	var cols []string
+	used := map[string]bool{}
+	for _, c := range columnOrder {
+		if colSet[c] {
+			cols = append(cols, c)
+			used[c] = true
+		}
+	}
+	remaining := make([]string, 0, len(colSet))
+	for c := range colSet {
+		if !used[c] {
+			remaining = append(remaining, c)
+		}
+	}
+	sort.Strings(remaining)
+	cols = append(cols, remaining...)
+	return rows, cols
+}
+
+// renderInlineColumnarTable renders a list of maps as a compact columnar table.
+func renderInlineColumnarTable(cols []string, rows []map[string]interface{}, width int, th *Theme) []string {
+	if len(cols) == 0 || len(rows) == 0 {
+		return nil
+	}
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(th.HeaderFG)
+	cellStyle := lipgloss.NewStyle().Foreground(th.ValueColor)
+
+	// Compute column widths from header + data.
+	colWidths := make([]int, len(cols))
+	for i, c := range cols {
+		colWidths[i] = runewidth.StringWidth(c)
+	}
+	cellValues := make([][]string, len(rows))
+	for r, row := range rows {
+		cellValues[r] = make([]string, len(cols))
+		for c, col := range cols {
+			var s string
+			if row[col] != nil {
+				s = fmt.Sprintf("%v", row[col])
+			}
+			cellValues[r][c] = s
+			if w := runewidth.StringWidth(s); w > colWidths[c] {
+				colWidths[c] = w
+			}
+		}
+	}
+
+	// Clamp total width.
+	gap := 2
+	totalWidth := 0
+	for _, w := range colWidths {
+		totalWidth += w
+	}
+	totalWidth += gap * (len(colWidths) - 1) // gaps between columns only
+	if totalWidth > width {
+		// Shrink widest columns proportionally.
+		excess := totalWidth - width
+		for excess > 0 {
+			maxIdx, maxW := 0, 0
+			for i, w := range colWidths {
+				if w > maxW {
+					maxIdx, maxW = i, w
+				}
+			}
+			if maxW <= 3 {
+				break
+			}
+			colWidths[maxIdx]--
+			excess--
+		}
+	}
+
+	// Render header.
+	var headerParts []string
+	for i, col := range cols {
+		cell := runewidth.Truncate(col, colWidths[i], "...")
+		cell += strings.Repeat(" ", colWidths[i]-runewidth.StringWidth(cell))
+		headerParts = append(headerParts, headerStyle.Render(cell))
+	}
+	sep := strings.Repeat(" ", gap)
+	lines := []string{strings.Join(headerParts, sep)}
+
+	// Render rows.
+	for _, cells := range cellValues {
+		var parts []string
+		for i, val := range cells {
+			cell := runewidth.Truncate(val, colWidths[i], "...")
+			cell += strings.Repeat(" ", colWidths[i]-runewidth.StringWidth(cell))
+			parts = append(parts, cellStyle.Render(cell))
+		}
+		lines = append(lines, strings.Join(parts, sep))
+	}
+	return lines
 }

--- a/internal/ui/detail_view_test.go
+++ b/internal/ui/detail_view_test.go
@@ -1,0 +1,425 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractNestedTable_HomogeneousArray(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       interface{}
+		columnOrder []string
+		wantRows    int
+		wantCols    []string
+	}{
+		{
+			name: "basic array of maps",
+			input: []interface{}{
+				map[string]interface{}{"name": "a", "status": "ok"},
+				map[string]interface{}{"name": "b", "status": "fail"},
+			},
+			wantRows: 2,
+			wantCols: []string{"name", "status"},
+		},
+		{
+			name: "column order respected",
+			input: []interface{}{
+				map[string]interface{}{"name": "a", "status": "ok", "flow": "x"},
+			},
+			columnOrder: []string{"status", "name"},
+			wantRows:    1,
+			wantCols:    []string{"status", "name", "flow"},
+		},
+		{
+			name: "column order with missing keys ignored",
+			input: []interface{}{
+				map[string]interface{}{"name": "a", "status": "ok"},
+			},
+			columnOrder: []string{"missing", "status"},
+			wantRows:    1,
+			wantCols:    []string{"status", "name"},
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			wantRows: 0,
+			wantCols: nil,
+		},
+		{
+			name:     "empty array",
+			input:    []interface{}{},
+			wantRows: 0,
+			wantCols: nil,
+		},
+		{
+			name:     "non-array input",
+			input:    "just a string",
+			wantRows: 0,
+			wantCols: nil,
+		},
+		{
+			name: "heterogeneous array (mixed types)",
+			input: []interface{}{
+				map[string]interface{}{"name": "a"},
+				"not a map",
+			},
+			wantRows: 0,
+			wantCols: nil,
+		},
+		{
+			name: "superset keys across rows",
+			input: []interface{}{
+				map[string]interface{}{"a": 1},
+				map[string]interface{}{"a": 2, "b": 3},
+			},
+			wantRows: 2,
+			wantCols: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, cols := extractNestedTable(tt.input, tt.columnOrder)
+			if tt.wantRows == 0 {
+				assert.Nil(t, rows)
+				assert.Nil(t, cols)
+			} else {
+				require.Len(t, rows, tt.wantRows)
+				assert.Equal(t, tt.wantCols, cols)
+			}
+		})
+	}
+}
+
+func TestRenderInlineColumnarTable(t *testing.T) {
+	th := CurrentTheme()
+
+	t.Run("basic rendering", func(t *testing.T) {
+		cols := []string{"name", "status"}
+		rows := []map[string]interface{}{
+			{"name": "work", "status": "authenticated"},
+			{"name": "personal", "status": "not authenticated"},
+		}
+		lines := renderInlineColumnarTable(cols, rows, 80, &th)
+		require.Len(t, lines, 3) // header + 2 rows
+		assert.Contains(t, stripANSI(lines[0]), "name")
+		assert.Contains(t, stripANSI(lines[0]), "status")
+		assert.Contains(t, stripANSI(lines[1]), "work")
+		assert.Contains(t, stripANSI(lines[2]), "personal")
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		lines := renderInlineColumnarTable(nil, nil, 80, &th)
+		assert.Nil(t, lines)
+	})
+
+	t.Run("empty cols", func(t *testing.T) {
+		lines := renderInlineColumnarTable([]string{}, []map[string]interface{}{{"a": 1}}, 80, &th)
+		assert.Nil(t, lines)
+	})
+
+	t.Run("narrow width triggers shrink", func(t *testing.T) {
+		cols := []string{"name", "very_long_status_column"}
+		rows := []map[string]interface{}{
+			{"name": "x", "very_long_status_column": "active"},
+		}
+		lines := renderInlineColumnarTable(cols, rows, 20, &th)
+		require.NotNil(t, lines)
+		for _, line := range lines {
+			// All lines should be rendered (may be truncated but still present)
+			assert.NotEmpty(t, stripANSI(line))
+		}
+	})
+
+	t.Run("nil values in rows", func(t *testing.T) {
+		cols := []string{"name", "status"}
+		rows := []map[string]interface{}{
+			{"name": "test", "status": nil},
+		}
+		lines := renderInlineColumnarTable(cols, rows, 80, &th)
+		require.Len(t, lines, 2) // header + 1 row
+	})
+}
+
+func TestBuildDetailViewModel(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "displayName",
+			Sections: []DetailSection{
+				{Title: "Info", Fields: []string{"status"}, Layout: DisplayLayoutTable},
+				{Title: "Tags", Fields: []string{"tags"}, Layout: DisplayLayoutTags},
+			},
+			HiddenFields: []string{"internal"},
+		},
+	}
+
+	t.Run("basic object", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"displayName": "Test Item",
+			"status":      "active",
+			"tags":        []interface{}{"a", "b"},
+			"internal":    "should-be-hidden",
+		}
+		dv := buildDetailViewModel(obj, schema, 80, 40)
+		require.NotNil(t, dv)
+		assert.Equal(t, "Test Item", dv.TitleText)
+		assert.NotEmpty(t, dv.Sections)
+	})
+
+	t.Run("nil object", func(t *testing.T) {
+		dv := buildDetailViewModel(nil, schema, 80, 40)
+		assert.Nil(t, dv)
+	})
+
+	t.Run("nil schema", func(t *testing.T) {
+		obj := map[string]interface{}{"name": "test"}
+		dv := buildDetailViewModel(obj, nil, 80, 40)
+		assert.Nil(t, dv)
+	})
+
+	t.Run("nil detail config", func(t *testing.T) {
+		obj := map[string]interface{}{"name": "test"}
+		s := &DisplaySchema{Detail: nil}
+		dv := buildDetailViewModel(obj, s, 80, 40)
+		assert.Nil(t, dv)
+	})
+
+	t.Run("non-map input", func(t *testing.T) {
+		dv := buildDetailViewModel("not a map", schema, 80, 40)
+		assert.Nil(t, dv)
+	})
+
+	t.Run("with nested table field", func(t *testing.T) {
+		nestedSchema := &DisplaySchema{
+			Detail: &DetailDisplayConfig{
+				TitleField: "name",
+				Sections: []DetailSection{
+					{
+						Title:       "Profiles",
+						Fields:      []string{"profiles"},
+						Layout:      DisplayLayoutTable,
+						ColumnOrder: []string{"name", "status"},
+					},
+				},
+			},
+		}
+		obj := map[string]interface{}{
+			"name": "GitHub",
+			"profiles": []interface{}{
+				map[string]interface{}{"name": "work", "status": "auth"},
+				map[string]interface{}{"name": "personal", "status": "none"},
+			},
+		}
+		dv := buildDetailViewModel(obj, nestedSchema, 80, 40)
+		require.NotNil(t, dv)
+		assert.Equal(t, "GitHub", dv.TitleText)
+		// The profiles section should have lines containing column data
+		require.NotEmpty(t, dv.Sections)
+		profileSection := dv.Sections[0]
+		assert.Equal(t, "Profiles", profileSection.Title)
+		require.NotEmpty(t, profileSection.Lines)
+		// Header + 2 rows
+		assert.GreaterOrEqual(t, len(profileSection.Lines), 3)
+	})
+
+	t.Run("uncovered fields go to Other section", func(t *testing.T) {
+		minSchema := &DisplaySchema{
+			Detail: &DetailDisplayConfig{
+				TitleField: "name",
+				Sections:   []DetailSection{},
+			},
+		}
+		obj := map[string]interface{}{
+			"name":  "Test",
+			"extra": "uncovered",
+		}
+		dv := buildDetailViewModel(obj, minSchema, 80, 40)
+		require.NotNil(t, dv)
+		// extra should appear in a generated section
+		assert.NotEmpty(t, dv.Sections)
+	})
+}
+
+func TestRenderDetailView_Output(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Title: "", Fields: []string{"status", "version"}, Layout: DisplayLayoutTable},
+				{Title: "Description", Fields: []string{"desc"}, Layout: DisplayLayoutParagraph},
+			},
+		},
+	}
+
+	obj := map[string]interface{}{
+		"name":    "GitHub",
+		"status":  "authenticated",
+		"version": "1.0",
+		"desc":    "This is a description paragraph.",
+	}
+
+	dv := buildDetailViewModel(obj, schema, 80, 100)
+	require.NotNil(t, dv)
+
+	output := dv.Render(80, 100, true)
+	assert.NotEmpty(t, output)
+	assert.Contains(t, output, "status")
+	assert.Contains(t, output, "authenticated")
+	assert.Contains(t, output, "Description")
+	assert.Contains(t, output, "This is a description paragraph.")
+}
+
+func TestRenderDetailView_NilModel(t *testing.T) {
+	output := renderDetailView(nil, nil, false)
+	assert.Equal(t, "  (no data)", output)
+}
+
+func TestRenderInlineSection(t *testing.T) {
+	obj := map[string]interface{}{
+		"a": "hello",
+		"b": "world",
+		"c": nil,
+	}
+	hidden := map[string]bool{}
+
+	lines := renderInlineSection(obj, []string{"a", "b", "c"}, 80, hidden)
+	require.Len(t, lines, 1)
+	plain := stripANSI(lines[0])
+	assert.Contains(t, plain, "hello")
+	assert.Contains(t, plain, "world")
+}
+
+func TestRenderInlineSection_HiddenFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"a": "visible",
+		"b": "hidden",
+	}
+	hidden := map[string]bool{"b": true}
+
+	lines := renderInlineSection(obj, []string{"a", "b"}, 80, hidden)
+	require.Len(t, lines, 1)
+	plain := stripANSI(lines[0])
+	assert.Contains(t, plain, "visible")
+	assert.NotContains(t, plain, "hidden")
+}
+
+func TestRenderInlineSection_AllNil(t *testing.T) {
+	obj := map[string]interface{}{"a": nil}
+	lines := renderInlineSection(obj, []string{"a"}, 80, map[string]bool{})
+	assert.Nil(t, lines)
+}
+
+func TestRenderParagraphSection(t *testing.T) {
+	obj := map[string]interface{}{
+		"desc": "Short paragraph.",
+	}
+	lines := renderParagraphSection(obj, []string{"desc"}, 80, map[string]bool{})
+	require.NotEmpty(t, lines)
+	assert.Contains(t, lines[0], "Short paragraph.")
+}
+
+func TestRenderTagsSection(t *testing.T) {
+	obj := map[string]interface{}{
+		"tags": []interface{}{"alpha", "beta", "gamma"},
+	}
+	lines := renderTagsSection(obj, []string{"tags"}, 200, map[string]bool{})
+	require.NotEmpty(t, lines)
+	plain := stripANSI(strings.Join(lines, " "))
+	assert.Contains(t, plain, "alpha")
+	assert.Contains(t, plain, "beta")
+	assert.Contains(t, plain, "gamma")
+}
+
+func TestRenderTagsSection_StringValue(t *testing.T) {
+	obj := map[string]interface{}{
+		"label": "single",
+	}
+	lines := renderTagsSection(obj, []string{"label"}, 80, map[string]bool{})
+	require.NotEmpty(t, lines)
+	assert.Contains(t, stripANSI(strings.Join(lines, " ")), "single")
+}
+
+func TestRenderTagsSection_Hidden(t *testing.T) {
+	obj := map[string]interface{}{
+		"tags": []interface{}{"a"},
+	}
+	lines := renderTagsSection(obj, []string{"tags"}, 80, map[string]bool{"tags": true})
+	assert.Nil(t, lines)
+}
+
+func TestRenderTableSection_WithNestedTable(t *testing.T) {
+	obj := map[string]interface{}{
+		"profiles": []interface{}{
+			map[string]interface{}{"name": "work", "status": "active"},
+			map[string]interface{}{"name": "home", "status": "inactive"},
+		},
+	}
+	lines := renderTableSection(obj, []string{"profiles"}, 80, map[string]bool{}, []string{"name", "status"})
+	require.NotEmpty(t, lines)
+	// Should have header + 2 data rows
+	assert.GreaterOrEqual(t, len(lines), 3)
+	plain := stripANSI(strings.Join(lines, "\n"))
+	assert.Contains(t, plain, "name")
+	assert.Contains(t, plain, "status")
+	assert.Contains(t, plain, "work")
+}
+
+func TestRenderTableSection_ScalarFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"name":   "test",
+		"status": "ok",
+	}
+	lines := renderTableSection(obj, []string{"name", "status"}, 80, map[string]bool{}, nil)
+	require.Len(t, lines, 2)
+	plain := stripANSI(strings.Join(lines, "\n"))
+	assert.Contains(t, plain, "name")
+	assert.Contains(t, plain, "test")
+	assert.Contains(t, plain, "status")
+	assert.Contains(t, plain, "ok")
+}
+
+func TestStringifyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		maxWidth int
+		want     string
+	}{
+		{"string", "hello", 80, "hello"},
+		{"int", 42, 80, "42"},
+		{"bool", true, 80, "true"},
+		{"nil", nil, 80, ""},
+		{"array", []interface{}{"a", "b"}, 80, "[a, b]"},
+		{"map", map[string]interface{}{"a": 1, "b": 2}, 80, "{2 keys}"},
+		{"truncated string", "very long string that should be truncated", 10, "very lo..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringifyValue(tt.input, tt.maxWidth)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildDetailView(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Fields: []string{"status"}, Layout: DisplayLayoutTable},
+			},
+		},
+	}
+	obj := map[string]interface{}{
+		"name":   "Test",
+		"status": "ok",
+	}
+	dv := BuildDetailView(obj, schema, 80, 40)
+	require.NotNil(t, dv)
+	assert.Equal(t, "Test", dv.TitleText)
+}

--- a/internal/ui/display_schema.go
+++ b/internal/ui/display_schema.go
@@ -82,6 +82,11 @@ type DetailSection struct {
 	//   - "tags"      — colored pill badges (for arrays of strings)
 	//   - "table"     — standard KEY/VALUE table rows (default)
 	Layout string `json:"layout,omitempty"`
+
+	// ColumnOrder specifies the preferred column order when a field contains
+	// []map[string]any data rendered as an inline table. Fields not listed
+	// are appended in alphabetical order after the specified ones.
+	ColumnOrder []string `json:"columnOrder,omitempty"`
 }
 
 // Layout constants for DetailSection.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -254,6 +254,10 @@ type Model struct {
 
 	// Status screen async completion (set by library consumers via Config.Done)
 	DoneChan <-chan StatusResult // Optional channel signaling async operation completion
+
+	// ExprProvider overrides CEL expression evaluation when set.
+	// It allows library consumers to inject custom expression handling.
+	ExprProvider ExpressionProvider
 }
 
 // DebugEvent captures a debug message with a timestamp for post-exit logging.
@@ -2976,6 +2980,24 @@ func SearchRows(node interface{}, query string) [][]string {
 	return rows
 }
 
+// evaluateExpression uses the per-instance ExprProvider when set,
+// otherwise falls back to the package-level EvaluateExpression.
+func (m *Model) evaluateExpression(expr string, root interface{}) (interface{}, error) {
+	if m.ExprProvider != nil {
+		return m.ExprProvider.Evaluate(expr, root)
+	}
+	return EvaluateExpression(expr, root)
+}
+
+// isExpression checks via the per-instance ExprProvider when set,
+// otherwise falls back to the package-level IsExpression.
+func (m *Model) isExpression(expr string) bool {
+	if m.ExprProvider != nil {
+		return m.ExprProvider.IsExpression(expr)
+	}
+	return IsExpression(expr)
+}
+
 func (m *Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{textinput.Blink}
 	if cv := m.activeCustomView(); cv != nil {
@@ -4543,7 +4565,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				// Use expression exactly as typed - no modifications
 				// Use the configured expression provider to respect custom CEL environments
-				if _, err := EvaluateExpression(evalExpr, m.Root); err != nil {
+				if _, err := m.evaluateExpression(evalExpr, m.Root); err != nil {
 					m.ErrMsg = fmt.Sprintf("explore expression error: %v", err)
 					return m, nil
 				}
@@ -4583,13 +4605,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					node, err := navigator.Navigate(m.Root, pathValue)
 					if err == nil {
 						// For free-form CEL, avoid NavigateTo to preserve input exactly
-						if (strings.Contains(pathValue, "(") && strings.Contains(pathValue, ")")) || IsExpression(pathValue) {
+						if (strings.Contains(pathValue, "(") && strings.Contains(pathValue, ")")) || m.isExpression(pathValue) {
 							newModel := InitialModel(node)
 							newModel.Root = m.Root
 							newModel.DebugMode = m.DebugMode
 							newModel.NoColor = m.NoColor
 							newModel.WinWidth = m.WinWidth
 							newModel.WinHeight = m.WinHeight
+							newModel.ExprProvider = m.ExprProvider
 							newModel.Path = pathValue
 							newModel.PathKeys = parsePathKeys(pathValue)
 							newModel.ApplyColorScheme()
@@ -4610,6 +4633,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						newModel.NoColor = m.NoColor
 						newModel.WinWidth = m.WinWidth
 						newModel.WinHeight = m.WinHeight
+						newModel.ExprProvider = m.ExprProvider
 						newModel.Path = normalizePathForModel(pathValue)
 						newModel.PathKeys = parsePathKeys(newModel.Path)
 						newModel.ApplyColorScheme()
@@ -6646,7 +6670,7 @@ func menuActionQuit(m *Model) tea.Cmd {
 		evalExpr = "_"
 	}
 	// Expressions are already properly formatted - don't modify them
-	if _, err := EvaluateExpression(evalExpr, m.Root); err != nil {
+	if _, err := m.evaluateExpression(evalExpr, m.Root); err != nil {
 		m.ErrMsg = fmt.Sprintf("explore expression error: %v", err)
 		m.StatusType = "error"
 		return nil

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oakwood-commons/kvx/internal/completion"
 	"github.com/oakwood-commons/kvx/internal/navigator"
@@ -2220,4 +2221,56 @@ func TestParseArrayIndex(t *testing.T) {
 	assert.Equal(t, -1, parseArrayIndex("abc"))
 	assert.Equal(t, -1, parseArrayIndex(""))
 	assert.Equal(t, -1, parseArrayIndex("[]"))
+}
+
+// mockExprProvider is a test helper for per-instance expression provider tests.
+type mockExprProvider struct {
+	evaluateCalled bool
+	isExprCalled   bool
+}
+
+func (p *mockExprProvider) Evaluate(_ string, _ interface{}) (interface{}, error) {
+	p.evaluateCalled = true
+	return "mock-result", nil
+}
+
+func (p *mockExprProvider) DiscoverSuggestions() []string { return nil }
+
+func (p *mockExprProvider) IsExpression(_ string) bool {
+	p.isExprCalled = true
+	return true
+}
+
+func TestModel_EvaluateExpression_PerInstance(t *testing.T) {
+	t.Run("uses ExprProvider when set", func(t *testing.T) {
+		mock := &mockExprProvider{}
+		m := &Model{ExprProvider: mock}
+		result, err := m.evaluateExpression("_.x", map[string]any{"x": 1})
+		require.NoError(t, err)
+		assert.Equal(t, "mock-result", result)
+		assert.True(t, mock.evaluateCalled)
+	})
+
+	t.Run("falls back to package-level when nil", func(t *testing.T) {
+		m := &Model{}
+		// Package-level provider (CEL) will evaluate this
+		result, err := m.evaluateExpression("1 + 2", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), result)
+	})
+}
+
+func TestModel_IsExpression_PerInstance(t *testing.T) {
+	t.Run("uses ExprProvider when set", func(t *testing.T) {
+		mock := &mockExprProvider{}
+		m := &Model{ExprProvider: mock}
+		assert.True(t, m.isExpression("anything"))
+		assert.True(t, mock.isExprCalled)
+	})
+
+	t.Run("falls back to package-level when nil", func(t *testing.T) {
+		m := &Model{}
+		assert.True(t, m.isExpression("_.items.filter(x, x > 0)"))
+		assert.False(t, m.isExpression("simple.path"))
+	})
 }

--- a/internal/ui/run_model.go
+++ b/internal/ui/run_model.go
@@ -115,7 +115,7 @@ func applyInitialExpr(m *Model, expr string) {
 		m.StatusType = "error"
 		return
 	}
-	isExpr := (strings.Contains(trimmed, "(") && strings.Contains(trimmed, ")")) || IsExpression(trimmed)
+	isExpr := (strings.Contains(trimmed, "(") && strings.Contains(trimmed, ")")) || m.isExpression(trimmed)
 	if isExpr {
 		normalizedPath := normalizePathForModel(trimmed)
 		if navigatedNode, err := navigator.Resolve(m.Root, normalizedPath); err == nil {
@@ -151,7 +151,7 @@ func printPendingCLIExpr(m *Model) {
 	if expr == "" {
 		return
 	}
-	node, err := EvaluateExpression(expr, m.Root)
+	node, err := m.evaluateExpression(expr, m.Root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "explore expression error: %v\n", err)
 		return

--- a/pkg/tui/display_schema.go
+++ b/pkg/tui/display_schema.go
@@ -189,6 +189,9 @@ func extractDisplaySchemaFromJSONSchema(raw map[string]any) *DisplaySchema {
 				if v, ok := sMap["layout"].(string); ok {
 					section.Layout = v
 				}
+				if v, ok := sMap["columnOrder"]; ok {
+					section.ColumnOrder = extractStringArray(v)
+				}
 				detail.Sections = append(detail.Sections, section)
 			}
 		}

--- a/pkg/tui/panel.go
+++ b/pkg/tui/panel.go
@@ -175,6 +175,11 @@ type TableOptions struct {
 	// (initially 10). A non-nil pointer to 0 disables multiline rendering.
 	// Set to -1 for unlimited, or a positive number to cap at that many lines.
 	MaxValueLines *int
+
+	// Schema provides a display schema for automatic column derivation and
+	// schema-aware rendering. When set and ColumnOrder/HiddenColumns are
+	// empty, DeriveTableOptionsFromSchema is called to populate them.
+	Schema *DisplaySchema
 }
 
 // RenderTable renders a two-column key/value table for the given node.
@@ -187,7 +192,59 @@ type TableOptions struct {
 // If Width is 0, terminal size is auto-detected.
 // When Bordered is true, the table shrinks to fit its content width rather
 // than always expanding to the full terminal width.
+// DeriveTableOptionsFromSchema extracts column ordering and hidden fields
+// from a DisplaySchema for use in non-interactive table rendering.
+// Column order is derived from list config (titleField, badgeFields,
+// secondaryFields, subtitleField). Hidden columns come from detail config
+// (hiddenFields).
+func DeriveTableOptionsFromSchema(ds *DisplaySchema) (columnOrder, hiddenColumns []string) {
+	if ds == nil {
+		return nil, nil
+	}
+	if ds.List != nil {
+		seen := map[string]bool{}
+		addUnique := func(field string) {
+			if field != "" && !seen[field] {
+				seen[field] = true
+				columnOrder = append(columnOrder, field)
+			}
+		}
+		addUnique(ds.List.TitleField)
+		for _, f := range ds.List.BadgeFields {
+			addUnique(f)
+		}
+		for _, f := range ds.List.SecondaryFields {
+			addUnique(f)
+		}
+		if ds.List.SubtitleField != "" {
+			addUnique(ds.List.SubtitleField)
+		}
+	}
+	if ds.Detail != nil {
+		seen := map[string]bool{}
+		for _, f := range ds.Detail.HiddenFields {
+			if !seen[f] {
+				seen[f] = true
+				hiddenColumns = append(hiddenColumns, f)
+			}
+		}
+	}
+	return columnOrder, hiddenColumns
+}
+
 func RenderTable(node any, opts TableOptions) string {
+	// Auto-apply schema-derived column options when Schema is set and the
+	// caller has not provided explicit overrides.
+	if opts.Schema != nil {
+		order, hidden := DeriveTableOptionsFromSchema(opts.Schema)
+		if len(opts.ColumnOrder) == 0 && len(order) > 0 {
+			opts.ColumnOrder = order
+		}
+		if len(opts.HiddenColumns) == 0 && len(hidden) > 0 {
+			opts.HiddenColumns = hidden
+		}
+	}
+
 	th := ui.CurrentTheme()
 	formatter.SetTableTheme(formatter.TableColors{
 		HeaderFG:       th.HeaderFG,
@@ -806,4 +863,136 @@ func renderTOML(node any) string {
 		return fmt.Sprintf("toml marshal error: %v\n", err)
 	}
 	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// High-level rendering helpers for library consumers (#63)
+// ---------------------------------------------------------------------------
+
+// CardListOptions configures the card-list renderer.
+type CardListOptions struct {
+	Width   int
+	Height  int
+	Schema  *DisplaySchema
+	NoColor bool
+}
+
+// RenderCardList renders an array of objects as detail-view cards using the
+// detail display schema (x-kvx-detail).  Each card is rendered via
+// BuildDetailView with sections, layouts, and nested tables.
+// Falls back to a plain table (via RenderTable) if no detail schema is
+// available or BuildDetailView returns nil.
+func RenderCardList(items []map[string]any, opts CardListOptions) string {
+	if opts.Width <= 0 {
+		opts.Width = 120
+	}
+	if opts.Height <= 0 {
+		opts.Height = 1000
+	}
+
+	var schema *ui.DisplaySchema
+	if opts.Schema != nil {
+		schema = opts.Schema
+	}
+
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		dv := ui.BuildDetailView(item, schema, opts.Width, opts.Height)
+		if dv == nil {
+			// No detail schema available -- fall back to plain table rendering
+			// for the entire array instead of silently skipping items.
+			anyItems := make([]any, len(items))
+			for i, it := range items {
+				anyItems[i] = it
+			}
+			return RenderTable(anyItems, TableOptions{
+				Width:   opts.Width,
+				NoColor: opts.NoColor,
+				Schema:  opts.Schema,
+			})
+		}
+		rendered := dv.Render(opts.Width, opts.Height, opts.NoColor)
+		lines = append(lines, rendered)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// DetailViewOptions configures the detail-view renderer.
+type DetailViewOptions struct {
+	Width   int
+	Height  int
+	Schema  *DisplaySchema
+	NoColor bool
+}
+
+// RenderDetailView renders a single object as a detail view using the detail
+// display schema (x-kvx-detail).  Sections, hidden fields, layouts, and
+// column ordering are all honoured.
+func RenderDetailView(obj any, opts DetailViewOptions) string {
+	if opts.Width <= 0 {
+		opts.Width = 120
+	}
+	if opts.Height <= 0 {
+		opts.Height = 1000 // large enough to show all content without scrolling
+	}
+
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return fmt.Sprintf("%v", obj)
+	}
+
+	var schema *ui.DisplaySchema
+	if opts.Schema != nil {
+		schema = opts.Schema
+	}
+
+	dv := ui.BuildDetailView(m, schema, opts.Width, opts.Height)
+	if dv == nil {
+		return fmt.Sprintf("%v", obj)
+	}
+	return dv.Render(opts.Width, opts.Height, opts.NoColor)
+}
+
+// RenderSchemaView renders data using the display schema: if the data is an
+// array of objects it uses card-list mode; if it's a single object it uses
+// detail-view mode.
+func RenderSchemaView(data any, schema *DisplaySchema, width int, noColor ...bool) string {
+	if width <= 0 {
+		width = 120
+	}
+	nc := len(noColor) > 0 && noColor[0]
+
+	switch v := data.(type) {
+	case []any:
+		items := make([]map[string]any, 0, len(v))
+		for _, elem := range v {
+			if m, ok := elem.(map[string]any); ok {
+				items = append(items, m)
+			}
+		}
+		if len(items) > 0 {
+			out := RenderCardList(items, CardListOptions{Width: width, Schema: schema, NoColor: nc})
+			if !strings.HasSuffix(out, "\n") {
+				out += "\n"
+			}
+			return out
+		}
+	case []map[string]any:
+		if len(v) > 0 {
+			out := RenderCardList(v, CardListOptions{Width: width, Schema: schema, NoColor: nc})
+			if !strings.HasSuffix(out, "\n") {
+				out += "\n"
+			}
+			return out
+		}
+	case map[string]any:
+		out := RenderDetailView(v, DetailViewOptions{Width: width, Schema: schema, NoColor: nc})
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		return out
+	}
+
+	// Fallback: just stringify.
+	return fmt.Sprintf("%v\n", data)
 }

--- a/pkg/tui/panel_test.go
+++ b/pkg/tui/panel_test.go
@@ -660,3 +660,229 @@ func TestRenderTable_PerCallMaxValueLines(t *testing.T) {
 	// Global should be restored after RenderTable returns
 	assert.Equal(t, 10, MaxValueLines())
 }
+
+func TestRenderCardList(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Fields: []string{"name", "desc"}, Layout: "table"},
+			},
+		},
+	}
+
+	t.Run("renders items", func(t *testing.T) {
+		items := []map[string]any{
+			{"name": "alpha", "desc": "First item"},
+			{"name": "beta", "desc": "Second item"},
+		}
+		out := RenderCardList(items, CardListOptions{Width: 80, Schema: schema})
+		// Title field is hidden from sections (used in header), but desc appears in content
+		assert.Contains(t, out, "First item")
+		assert.Contains(t, out, "Second item")
+	})
+
+	t.Run("nil schema falls back to table", func(t *testing.T) {
+		items := []map[string]any{{"name": "x"}}
+		out := RenderCardList(items, CardListOptions{Width: 80})
+		assert.NotEmpty(t, out)
+		assert.Contains(t, out, "x")
+	})
+
+	t.Run("empty items", func(t *testing.T) {
+		out := RenderCardList(nil, CardListOptions{Width: 80, Schema: schema})
+		assert.Empty(t, out)
+	})
+}
+
+func TestRenderDetailView(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Fields: []string{"status", "version"}, Layout: "table"},
+			},
+		},
+	}
+
+	t.Run("renders object", func(t *testing.T) {
+		obj := map[string]any{"name": "test", "status": "ok", "version": "1.0"}
+		out := RenderDetailView(obj, DetailViewOptions{Width: 80, Schema: schema})
+		assert.Contains(t, out, "status")
+		assert.Contains(t, out, "ok")
+	})
+
+	t.Run("non-map returns stringified", func(t *testing.T) {
+		out := RenderDetailView("scalar", DetailViewOptions{Width: 80})
+		assert.Equal(t, "scalar", out)
+	})
+
+	t.Run("nil schema returns fallback", func(t *testing.T) {
+		obj := map[string]any{"key": "val"}
+		out := RenderDetailView(obj, DetailViewOptions{Width: 80})
+		// No schema -> BuildDetailView returns nil -> fallback to Sprintf
+		assert.Contains(t, out, "val")
+	})
+}
+
+func TestRenderSchemaView(t *testing.T) {
+	detailSchema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Fields: []string{"status"}, Layout: "table"},
+			},
+		},
+	}
+
+	t.Run("map uses detail view", func(t *testing.T) {
+		obj := map[string]any{"name": "single", "status": "ok"}
+		out := RenderSchemaView(obj, detailSchema, 80)
+		assert.NotEmpty(t, out)
+		assert.Contains(t, out, "status")
+	})
+
+	t.Run("nil schema returns fallback", func(t *testing.T) {
+		obj := map[string]any{"name": "x"}
+		out := RenderSchemaView(obj, nil, 80)
+		assert.NotEmpty(t, out)
+	})
+
+	t.Run("scalar returns stringified", func(t *testing.T) {
+		out := RenderSchemaView("hello", detailSchema, 80)
+		assert.Contains(t, out, "hello")
+	})
+}
+
+func TestDeriveTableOptionsFromSchema(t *testing.T) {
+	t.Run("nil schema returns nil", func(t *testing.T) {
+		order, hidden := DeriveTableOptionsFromSchema(nil)
+		assert.Nil(t, order)
+		assert.Nil(t, hidden)
+	})
+
+	t.Run("list config derives column order", func(t *testing.T) {
+		ds := &DisplaySchema{
+			List: &ListDisplayConfig{
+				TitleField:      "name",
+				SubtitleField:   "description",
+				BadgeFields:     []string{"version", "category"},
+				SecondaryFields: []string{"status"},
+			},
+		}
+		order, hidden := DeriveTableOptionsFromSchema(ds)
+		assert.Equal(t, []string{"name", "version", "category", "status", "description"}, order)
+		assert.Nil(t, hidden)
+	})
+
+	t.Run("detail config derives hidden columns", func(t *testing.T) {
+		ds := &DisplaySchema{
+			Detail: &DetailDisplayConfig{
+				HiddenFields: []string{"internal", "secret"},
+			},
+		}
+		order, hidden := DeriveTableOptionsFromSchema(ds)
+		assert.Nil(t, order)
+		assert.Equal(t, []string{"internal", "secret"}, hidden)
+	})
+
+	t.Run("both list and detail", func(t *testing.T) {
+		ds := &DisplaySchema{
+			List: &ListDisplayConfig{
+				TitleField:  "name",
+				BadgeFields: []string{"version"},
+			},
+			Detail: &DetailDisplayConfig{
+				HiddenFields: []string{"internal"},
+			},
+		}
+		order, hidden := DeriveTableOptionsFromSchema(ds)
+		assert.Equal(t, []string{"name", "version"}, order)
+		assert.Equal(t, []string{"internal"}, hidden)
+	})
+
+	t.Run("empty list config returns nil order", func(t *testing.T) {
+		ds := &DisplaySchema{List: &ListDisplayConfig{}}
+		order, _ := DeriveTableOptionsFromSchema(ds)
+		assert.Nil(t, order)
+	})
+
+	t.Run("duplicate fields deduplicated", func(t *testing.T) {
+		ds := &DisplaySchema{
+			List: &ListDisplayConfig{
+				TitleField:      "name",
+				BadgeFields:     []string{"name", "status"},
+				SecondaryFields: []string{"status"},
+			},
+		}
+		order, _ := DeriveTableOptionsFromSchema(ds)
+		assert.Equal(t, []string{"name", "status"}, order)
+	})
+}
+
+func TestRenderTable_WithSchema(t *testing.T) {
+	schema := &DisplaySchema{
+		List: &ListDisplayConfig{
+			TitleField:  "name",
+			BadgeFields: []string{"status"},
+		},
+		Detail: &DetailDisplayConfig{
+			HiddenFields: []string{"internal"},
+		},
+	}
+
+	data := []any{
+		map[string]any{"name": "alpha", "status": "ok", "internal": "hidden", "extra": "val"},
+		map[string]any{"name": "beta", "status": "fail", "internal": "hidden2", "extra": "val2"},
+	}
+
+	out := RenderTable(data, TableOptions{Width: 120, Schema: schema})
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "beta")
+	assert.NotContains(t, out, "hidden")
+	assert.NotContains(t, out, "hidden2")
+}
+
+func TestRender_SchemaRoutesDetailView(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections: []DetailSection{
+				{Fields: []string{"status"}, Layout: "table"},
+			},
+		},
+	}
+
+	obj := map[string]any{"name": "test", "status": "ok"}
+
+	for _, format := range []OutputFormat{FormatTable, FormatAuto} {
+		t.Run(string(format), func(t *testing.T) {
+			out := Render(obj, format, TableOptions{Width: 80, Schema: schema})
+			assert.Contains(t, out, "status")
+			assert.Contains(t, out, "ok")
+		})
+	}
+}
+
+func TestRender_SchemaArrayUsesColumnar(t *testing.T) {
+	schema := &DisplaySchema{
+		Detail: &DetailDisplayConfig{
+			TitleField: "name",
+			Sections:   []DetailSection{{Fields: []string{"status"}, Layout: "table"}},
+		},
+		List: &ListDisplayConfig{
+			TitleField:  "name",
+			BadgeFields: []string{"status"},
+		},
+	}
+
+	data := []any{
+		map[string]any{"name": "a", "status": "ok"},
+		map[string]any{"name": "b", "status": "fail"},
+	}
+
+	out := Render(data, FormatTable, TableOptions{Width: 120, Schema: schema})
+	// Arrays should NOT route to detail view -- should use columnar table
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -163,6 +163,9 @@ func Run(root interface{}, cfg Config, opts ...tea.ProgramOption) error {
 		if cfg.Done != nil {
 			m.DoneChan = cfg.Done
 		}
+		if cfg.ExpressionProvider != nil {
+			m.ExprProvider = cfg.ExpressionProvider
+		}
 		if cfg.KeyMode != "" && ui.IsValidKeyMode(cfg.KeyMode) {
 			m.KeyMode = ui.KeyMode(cfg.KeyMode)
 		}
@@ -235,6 +238,9 @@ func RenderSnapshot(root interface{}, cfg Config) string {
 		}
 		if cfg.DisplaySchema != nil {
 			m.DisplaySchema = cfg.DisplaySchema
+		}
+		if cfg.ExpressionProvider != nil {
+			m.ExprProvider = cfg.ExpressionProvider
 		}
 		if cfg.KeyMode != "" && ui.IsValidKeyMode(cfg.KeyMode) {
 			m.KeyMode = ui.KeyMode(cfg.KeyMode)


### PR DESCRIPTION
Add schema-driven detail view for non-interactive CLI output (#62, #63):
- BuildDetailView public API for library consumers (pkg/tui)
- Nested table detection and inline columnar rendering for []map fields
- ColumnOrder support in DetailSection for preferred column ordering
- columnOrder parsing in JSON Schema display schema extractor
- RenderCardList, RenderDetailView, RenderSchemaView in pkg/tui/panel.go
- Schema-aware rendering in printEvalResult for -o table and -o auto

Add per-instance ExpressionProvider on Model:
- evaluateExpression/isExpression instance methods with nil fallback
- ExprProvider wiring in both Run() and RenderSnapshot()

Add platform-specific hook scripts for Windows:
- git-safety.json and go-format.json use platform field (win32/darwin/linux)
- PowerShell scripts for Windows, bash for Unix

Add AI customization files:
- go-fixer agent, startup-check prompt
- integration-tests and tui-conventions instructions

Add tests:
- 20 tests in detail_view_test.go (nested tables, sections, layouts)
- 4 tests in model_test.go (per-instance expression provider)
- 9 tests in panel_test.go (card list, detail view, schema view)

Closes #62
Closes #63
Closes #64
Closes #65